### PR TITLE
Adding updatePolicy api to the base product

### DIFF
--- a/contracts/interface/IProduct.sol
+++ b/contracts/interface/IProduct.sol
@@ -54,4 +54,6 @@ interface IProduct {
     function updateCoverLimit(uint256 _policyID, uint256 _coverLimit) external payable;
     function extendPolicy(uint256 _policyID, uint64 _blocks) external payable;
     function cancelPolicy(uint256 _policyID) external;
+    function updatePolicy(uint256 _policyID, uint256 _coverLimit, uint64 _blocks ) external payable;
+
 }


### PR DESCRIPTION
- Created new api **updatePolicy** for the base product.
- Extracted the business logic from **updateCoverLimit** and **extendPolicy** to the private functions.
