### PR TITLE
GovernanceSink: a safer alternative to renounceOwnership

### DIFF
--- a/contracts/ERC721Enhanced.sol
+++ b/contracts/ERC721Enhanced.sol
@@ -174,7 +174,7 @@ abstract contract ERC721Enhanced is ERC721Enumerable, IERC721Enhanced, EIP712 {
     ***************************************/
 
     // Call will revert if the token does not exist.
-    modifier tokenMustExist(uint256 tokenID) override {
+    modifier tokenMustExist(uint256 tokenID) {
         require(_exists(tokenID), "query for nonexistent token");
         _;
     }

--- a/contracts/GovernanceSink.sol
+++ b/contracts/GovernanceSink.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.6;
+
+import "./interface/IGovernable.sol";
+import "./interface/IGovernanceSink.sol";
+
+
+/**
+ * @title GovernanceSink
+ * @author solace.fi
+ * @notice An inert holder of governance roles.
+ *
+ * There will come a time when our contracts become self-sustaining and no longer require a [**governor**](/docs/protocol/governance). When that time comes, `GovernanceSink` will be the holder of the governance role.
+ *
+ * OpenZeppelin's `renounceOwnership()` is vulnerable to 'reinitialization exploits' in which a contract asserts that an initialization function only runs once. In reality, the contract checks `owner == address(0x0)`, which once again becomes true after `renounceOwnership()`. An attacker can rerun the initialization function and set themselves as owner. Transferring the governance role to `GovernanceSink` is a safer alternative as `GovernanceSink` cannot do anything besides hold the role.
+ */
+contract GovernanceSink is IGovernanceSink {
+
+    /**
+     * @notice Accepts the governance role for a given contract.
+     * This action cannot be reversed.
+     * Before you call it, ask yourself:
+     *   - Is the contract self-sustaining?
+     *   - Is there a chance you will need governance privileges in the future?
+     * Note that there is no access control on this function.
+     * Assume it will be called immediately after `renouncingContract.setGovernance()`.
+     * @param renouncingContract The address of the contract to renounce governance. Must have already `setGovernance()`.
+     */
+    function sinkGovernance(address renouncingContract) external override {
+        IGovernable gov = IGovernable(renouncingContract);
+        // if renouncingContract is actually IGovernable, this check is redundant
+        // if not, prevents calling renouncingContract fallback
+        require(gov.pendingGovernance() == address(this), "governance not set");
+        gov.acceptGovernance();
+    }
+}

--- a/contracts/interface/IERC721Enhanced.sol
+++ b/contracts/interface/IERC721Enhanced.sol
@@ -98,11 +98,4 @@ interface IERC721Enhanced is IERC721Enumerable {
      * @return tokenIDs The list of token IDs.
      */
     function listTokensOfOwner(address owner) external view returns (uint256[] memory tokenIDs);
-
-    /***************************************
-    MODIFIERS
-    ***************************************/
-
-    // Call will revert if the token does not exist.
-    modifier tokenMustExist(uint256 tokenID) virtual;
 }

--- a/contracts/interface/IGovernanceSink.sol
+++ b/contracts/interface/IGovernanceSink.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.6;
+
+/**
+ * @title IGovernanceSink
+ * @author solace.fi
+ * @notice An inert holder of governance roles.
+ *
+ * There will come a time when our contracts become self-sustaining and no longer require a [**governor**](/docs/protocol/governance). When that time comes, `GovernanceSink` will be the holder of the governance role.
+ *
+ * OpenZeppelin's `renounceOwnership()` is vulnerable to 'reinitialization exploits' in which a contract asserts that an initialization function only runs once. In reality, the contract checks `owner == address(0x0)`, which once again becomes true after `renounceOwnership()`. An attacker can rerun the initialization function and set themselves as owner. Transferring the governance role to `GovernanceSink` is a safer alternative as `GovernanceSink` cannot do anything besides hold the role.
+ */
+interface IGovernanceSink {
+
+    /**
+     * @notice Accepts the governance role for a given contract.
+     * This action cannot be reversed.
+     * Before you call it, ask yourself:
+     *   - Is the contract self-sustaining?
+     *   - Is there a chance you will need governance privileges in the future?
+     * Note that there is no access control on this function.
+     * Assume it will be called immediately after `renouncingContract.setGovernance()`.
+     * @param renouncingContract The address of the contract to renounce governance. Must have already `setGovernance()`.
+     */
+    function sinkGovernance(address renouncingContract) external;
+}

--- a/test/utilities/artifact_importer.ts
+++ b/test/utilities/artifact_importer.ts
@@ -54,6 +54,7 @@ export async function import_artifacts() {
   artifacts.MockERC1271 = await tryImport(`${artifact_dir}/mocks/MockERC1271.sol/MockERC1271.json`);
   artifacts.Blacklist = await tryImport(`${artifact_dir}/interface/IBlacklist.sol/IBlacklist.json`);
   artifacts.SingletonFactory = await tryImport(`${artifact_dir}/interface/ISingletonFactory.sol/ISingletonFactory.json`);
+  artifacts.GovernanceSink = await tryImport(`${artifact_dir}/GovernanceSink.sol/GovernanceSink.json`);
 
   // aave imports
   artifacts.LendingPool = await tryImport(`${artifact_dir}/interface/AaveV2/ILendingPool.sol/ILendingPool.json`);


### PR DESCRIPTION
An inert holder of governance roles.

There will come a time when our contracts become self-sustaining and no longer require a governor. When that time comes, `GovernanceSink` will be the holder of the governance role.

OpenZeppelin's `renounceOwnership()` is vulnerable to 'reinitialization exploits' in which a contract asserts that an initialization function only runs once. In reality, the contract checks `owner == address(0x0)`, which once again becomes true after `renounceOwnership()`. An attacker can rerun the initialization function and set themselves as owner. Transferring the governance role to `GovernanceSink` is a safer alternative as `GovernanceSink` cannot do anything besides hold the role.