### PR TITLE
Soteria & Risk Manager - enhance unit test coverage

### DIFF
--- a/test/CoverageDataProvider.test.ts
+++ b/test/CoverageDataProvider.test.ts
@@ -449,13 +449,13 @@ describe("CoverageDataProvider", function() {
 
     it("should safely remove an asset that is not in the last index of _indexToAsset mapping", async function () {
       // OVERALL - Remove and re-add wBTC @ index 6
-      let removed_asset = await coverageDataProvider.connect(user).assetAt(6);
-      expect(removed_asset.asset_).to.be.equal(WBTC);
-      expect(removed_asset.assetType_).to.be.equal(ASSET_TYPE.ERC20);
+      let removedAsset = await coverageDataProvider.connect(user).assetAt(6);
+      expect(removedAsset.asset_).to.be.equal(WBTC);
+      expect(removedAsset.assetType_).to.be.equal(ASSET_TYPE.ERC20);
 
-      let last_index_asset = await coverageDataProvider.connect(user).assetAt(7);
-      expect(last_index_asset.asset_).to.be.equal(USDT);
-      expect(last_index_asset.assetType_).to.be.equal(ASSET_TYPE.ERC20);
+      let lastIndexAsset = await coverageDataProvider.connect(user).assetAt(7);
+      expect(lastIndexAsset.asset_).to.be.equal(USDT);
+      expect(lastIndexAsset.assetType_).to.be.equal(ASSET_TYPE.ERC20);
       
       // Remove WBTC from _indexToAsset
       let tx = await coverageDataProvider.connect(governor).removeAsset(WBTC);
@@ -463,9 +463,9 @@ describe("CoverageDataProvider", function() {
       expect(await coverageDataProvider.connect(user).numOfAssets()).to.be.equal(6);
 
       // Check that current index 6 is now the previous index 7 (USDT)
-      last_index_asset = await coverageDataProvider.connect(user).assetAt(6);
-      expect(last_index_asset.asset_).to.be.equal(USDT);
-      expect(last_index_asset.assetType_).to.be.equal(ASSET_TYPE.ERC20);
+      lastIndexAsset = await coverageDataProvider.connect(user).assetAt(6);
+      expect(lastIndexAsset.asset_).to.be.equal(USDT);
+      expect(lastIndexAsset.assetType_).to.be.equal(ASSET_TYPE.ERC20);
 
       // Restore state of _indexToAsset mapping to before unit test started
       await coverageDataProvider.connect(governor).removeAsset(USDT);
@@ -473,13 +473,13 @@ describe("CoverageDataProvider", function() {
       await coverageDataProvider.connect(governor).addAsset(USDT, ASSET_TYPE.ERC20);
       expect(await coverageDataProvider.connect(user).numOfAssets()).to.be.equal(7);
 
-      removed_asset = await coverageDataProvider.connect(user).assetAt(6);
-      expect(removed_asset.asset_).to.be.equal(WBTC);
-      expect(removed_asset.assetType_).to.be.equal(ASSET_TYPE.ERC20);
+      removedAsset = await coverageDataProvider.connect(user).assetAt(6);
+      expect(removedAsset.asset_).to.be.equal(WBTC);
+      expect(removedAsset.assetType_).to.be.equal(ASSET_TYPE.ERC20);
 
-      last_index_asset = await coverageDataProvider.connect(user).assetAt(7);
-      expect(last_index_asset.asset_).to.be.equal(USDT);
-      expect(last_index_asset.assetType_).to.be.equal(ASSET_TYPE.ERC20);
+      lastIndexAsset = await coverageDataProvider.connect(user).assetAt(7);
+      expect(lastIndexAsset.asset_).to.be.equal(USDT);
+      expect(lastIndexAsset.assetType_).to.be.equal(ASSET_TYPE.ERC20);
     })
   });
 

--- a/test/CoverageProduct.test.ts
+++ b/test/CoverageProduct.test.ts
@@ -243,7 +243,7 @@ describe("CoverageProduct", function () {
       await expect(product.connect(policyholder1).setMaxPeriod(maxPeriod1)).to.be.revertedWith("!governance");
     });
 
-    it("should revert setMaxPeriod if greater than maxPeriod", async function () {
+    it("should revert setMaxPeriod if lesser than minPeriod", async function () {
       let minPeriod = await product.minPeriod();
       await expect(product.connect(governor).setMaxPeriod(minPeriod - 1)).to.be.revertedWith("invalid period");
     });
@@ -470,7 +470,8 @@ describe("CoverageProduct", function () {
 
     it("can extend your policy after transfer", async function () {
       await policyManager.connect(policyholder1).transferFrom(policyholder1.address, policyholder2.address, policyID);
-      await product.connect(policyholder2).extendPolicy(policyID, extension, { value: quote });
+      let tx = await product.connect(policyholder2).extendPolicy(policyID, extension, { value: quote });
+      await expect(tx).to.emit(product, "PolicyExtended").withArgs(policyID);
       await policyManager.connect(policyholder2).transferFrom(policyholder2.address, policyholder1.address, policyID);
     });
   });

--- a/test/PolicyManager.test.ts
+++ b/test/PolicyManager.test.ts
@@ -261,14 +261,17 @@ describe("PolicyManager", function() {
     });
     it("cannot update nonexistent policy", async function() {
       await expect(policyManager.setPolicyInfo(2, coverAmount, expirationBlock, price, positionContract.address, riskStrategy.address)).to.be.revertedWith("query for nonexistent token");
+      await expect(policyManager.updatePolicyInfo(2, coverAmount, expirationBlock, price, riskStrategy.address)).to.be.revertedWith("query for nonexistent token");
     });
     it("product cannot update other products policy", async function() {
       await expect(policyManager.setPolicyInfo(1, coverAmount, expirationBlock, price, positionContract.address, riskStrategy.address)).to.be.revertedWith("wrong product");
+      await expect(policyManager.updatePolicyInfo(1, coverAmount, expirationBlock, price, riskStrategy.address)).to.be.revertedWith("wrong product");
     });
     it("can set policy info", async function() {
       let policyDescription = "0xabcd1234";
       // users must provide valid risk strategy
-      await policyManager.connect(walletProduct2).setPolicyInfo(1, 1, 2, 3, policyDescription, riskStrategy.address);
+      let tx = await policyManager.connect(walletProduct2).setPolicyInfo(1, 1, 2, 3, policyDescription, riskStrategy.address);
+      expect(tx).to.emit(policyManager, "PolicyUpdated").withArgs(1);
       expect(await policyManager.getPolicyholder(1)).to.equal(user.address);
       expect(await policyManager.getPolicyProduct(1)).to.equal(walletProduct2.address);
       expect(await policyManager.getPositionDescription(1)).to.equal(policyDescription);
@@ -283,6 +286,22 @@ describe("PolicyManager", function() {
       expect(await policyManager.activeCoverAmountPerStrategy(riskStrategy.address)).to.equal(1);
       expect(await riskManager.minCapitalRequirementPerStrategy(riskStrategy.address)).to.equal(1);
     });
+    it("can update policy info with same parameters", async function () {
+      let tx = await policyManager.connect(walletProduct2).updatePolicyInfo(1, 1, 2, 3, riskStrategy.address);
+      expect(tx).to.emit(policyManager, "PolicyUpdated").withArgs(1);
+      expect(await policyManager.getPolicyholder(1)).to.equal(user.address);
+      expect(await policyManager.getPolicyProduct(1)).to.equal(walletProduct2.address);
+      expect(await policyManager.getPolicyCoverAmount(1)).to.equal(1);
+      expect(await policyManager.getPolicyExpirationBlock(1)).to.equal(2);
+      expect(await policyManager.getPolicyPrice(1)).to.equal(3);
+      expect(await policyManager.policyIsActive(1)).to.equal(false);
+      expect(await policyManager.exists(1)).to.equal(true);
+      expect(await policyManager.activeCoverAmount()).to.equal(1);
+      expect(await riskManager.minCapitalRequirement()).to.equal(1);
+      expect(await policyManager.getPolicyRiskStrategy(1)).to.equal(riskStrategy.address);
+      expect(await policyManager.activeCoverAmountPerStrategy(riskStrategy.address)).to.equal(1);
+      expect(await riskManager.minCapitalRequirementPerStrategy(riskStrategy.address)).to.equal(1);
+    })
     it("can list my policies", async function() {
       expect(await policyManager.listTokensOfOwner(deployer.address)).to.deep.equal([]);
       expect(await policyManager.listTokensOfOwner(user.address)).to.deep.equal([BN.from(1)]);
@@ -397,6 +416,10 @@ describe("PolicyManager", function() {
   describe("updateActivePolicies", async function() {
     before(async function() {
       let productFactory: ProductFactory;
+
+      // Send extra ETH to governor to avoid insufficient funds error in `npx hardhat coverage --testfiles test/PolicyManager.test.ts`
+      const bal_priceOracle = await priceOracle.getBalance()
+      await priceOracle.sendTransaction({to: governor.address, value: bal_priceOracle.mul(999).div(1000)})
 
       // deploy product factory
       productFactory = (await deployContract(deployer, artifacts.ProductFactory)) as ProductFactory;
@@ -604,6 +627,7 @@ describe("PolicyManager", function() {
       let prevSoteriaActiveCoverAmount = await policyManager.activeCoverAmountPerStrategy(soteriaProduct.address);
       let tx = await soteriaProduct.connect(soteriaPolicyholder).activatePolicy(soteriaPolicyholder.address, COVER_AMOUNT, COVER_AMOUNT, {value: COVER_AMOUNT});
       await expect(tx).emit(soteriaProduct, "PolicyCreated").withArgs(BN.from("1"));
+      await expect(tx).emit(policyManager, "SoteriaProductCoverAmountUpdated").withArgs(COVER_AMOUNT);
 
       expect(await policyManager.activeCoverAmount()).to.equal(prevActiveCoverAmount.add(COVER_AMOUNT));
       expect(await policyManager.activeCoverAmountPerStrategy(soteriaProduct.address)).to.equal(prevSoteriaActiveCoverAmount.add(COVER_AMOUNT));

--- a/test/PolicyManager.test.ts
+++ b/test/PolicyManager.test.ts
@@ -418,8 +418,8 @@ describe("PolicyManager", function() {
       let productFactory: ProductFactory;
 
       // Send extra ETH to governor to avoid insufficient funds error in `npx hardhat coverage --testfiles test/PolicyManager.test.ts`
-      const bal_priceOracle = await priceOracle.getBalance()
-      await priceOracle.sendTransaction({to: governor.address, value: bal_priceOracle.mul(999).div(1000)})
+      const balancePriceOracle = await priceOracle.getBalance()
+      await priceOracle.sendTransaction({to: governor.address, value: balancePriceOracle.mul(999).div(1000)})
 
       // deploy product factory
       productFactory = (await deployContract(deployer, artifacts.ProductFactory)) as ProductFactory;

--- a/test/RiskStrategy.test.ts
+++ b/test/RiskStrategy.test.ts
@@ -527,4 +527,32 @@ describe("RiskStrategy", function () {
       // TODO: test case where mc >= ac
     });
   });
+
+  describe("setRiskManager", function () {
+    let riskManager2: RiskManager;
+
+    before(async function () {
+      riskManager2 = await deployContract(deployer, artifacts.RiskManager, [governor.address, registry.address]) as RiskManager;
+      expect(await riskStrategy.connect(governor).riskManager()).eq(riskManager.address)
+    })
+    
+    it("should revert on zero address risk manager", async function () {
+      await expect(riskStrategy.connect(governor).setRiskManager(ZERO_ADDRESS)).to.be.revertedWith("zero address risk manager")
+    })
+
+    it("should reject setRiskManager by non-governance", async function () {
+      await expect(riskStrategy.connect(user).setRiskManager(riskManager2.address)).to.be.revertedWith("!governance")
+    })
+
+    it("should should setRiskManager", async function () {
+      let tx = await riskStrategy.connect(governor).setRiskManager(riskManager2.address);
+      expect(tx).emit(riskStrategy, "RiskManagerSet").withArgs(riskManager2.address);
+      expect(await riskStrategy.connect(governor).riskManager()).eq(riskManager2.address)
+    })
+
+    after(async function () {
+      await riskStrategy.connect(governor).setRiskManager(riskManager.address);
+      expect(await riskStrategy.connect(governor).riskManager()).eq(riskManager.address)
+    })
+  })
 });


### PR DESCRIPTION
Made minor additions to increase unit test coverage for
- test/PolicyManager.test.ts
- test/RiskManager.test.ts
- test/RiskStrategy.test.ts
- test/CoverageProduct.test.ts
- test/CoverageDataProvider.test.ts

Within test/SoteriaCoverageProduct.test.ts, we haven't tested SoteriaCoverageProduct.submitClaim() but the task to integrate this function with ClaimsEscrow.sol is currently on hold