### PR TITLE
Refactor/soteria (WIP)

### DIFF
--- a/contracts/PolicyManager.sol
+++ b/contracts/PolicyManager.sol
@@ -367,7 +367,7 @@ contract PolicyManager is ERC721Enhanced, IPolicyManager, Governable {
      * This function is only called by `SoteriaCoverageProduct` when a new policy is bought or updated.
      * @param newCoverAmount The new cover amount.
     */
-    function setSoteriaActiveCoverAmount(uint256 newCoverAmount) external override {
+    function setSoteriaActiveCoverLimit(uint256 newCoverAmount) external override {
         require(address(_soteriaCoverageProduct) != address(0x0), "no soteria product");
         require(msg.sender == address(_soteriaCoverageProduct), "only soteria product");
         uint256 coverAmount = _activeCoverAmount;

--- a/contracts/PolicyManager.sol
+++ b/contracts/PolicyManager.sol
@@ -367,7 +367,7 @@ contract PolicyManager is ERC721Enhanced, IPolicyManager, Governable {
      * This function is only called by `SoteriaCoverageProduct` when a new policy is bought or updated.
      * @param newCoverAmount The new cover amount.
     */
-    function setSoteriaActiveCoverLimit(uint256 newCoverAmount) external override {
+    function setSoteriaActiveCoverAmount(uint256 newCoverAmount) external override {
         require(address(_soteriaCoverageProduct) != address(0x0), "no soteria product");
         require(msg.sender == address(_soteriaCoverageProduct), "only soteria product");
         uint256 coverAmount = _activeCoverAmount;

--- a/contracts/PolicyManager.sol
+++ b/contracts/PolicyManager.sol
@@ -10,8 +10,8 @@ import "./ERC721Enhanced.sol";
 import "./interface/IProduct.sol";
 import "./interface/IPolicyManager.sol";
 import "./interface/IPolicyDescriptor.sol";
-import "./interface/ISoteriaCoverageProduct.sol";
-
+import "./interface/IRegistry.sol";
+import "./interface/IRiskManager.sol";
 
 /**
  * @title PolicyManager
@@ -29,18 +29,14 @@ contract PolicyManager is ERC721Enhanced, IPolicyManager, Governable {
     /***************************************
     GLOBAL VARIABLES
     ***************************************/
+    /// @notice The Registry contract.
+    IRegistry internal _registry;
 
     /// @notice The address of the policy descriptor contract, which handles generating token URIs for policies.
     address internal _policyDescriptor;
 
-    /// @notice solace.fi Soteria coverage product.
-    ISoteriaCoverageProduct internal _soteriaCoverageProduct;
-
     /// @notice Set of products.
     EnumerableSet.AddressSet internal products;
-
-    // The current amount covered (in wei).
-    uint256 internal _activeCoverAmount;
 
     /// @notice Total policy count.
     uint256 internal _totalPolicyCount = 0;
@@ -48,14 +44,14 @@ contract PolicyManager is ERC721Enhanced, IPolicyManager, Governable {
     /// @notice Policy info (policy ID => policy info).
     mapping(uint256 => PolicyInfo) internal _policyInfo;
 
-    /// @notice The current amount covered (in wei) per strategy;
-    mapping(address => uint256) internal _activeCoverAmountPerStrategy;
-
     /**
      * @notice Constructs the `PolicyManager`.
      * @param governance_ The address of the [governor](/docs/protocol/governance).
      */
-    constructor(address governance_) ERC721Enhanced("Solace Policy", "SPT") Governable(governance_) { }
+    constructor(address governance_, address registry_) ERC721Enhanced("Solace Policy", "SPT") Governable(governance_) { 
+        require(address(registry_) != address(0x0), "zero address registry");
+        _registry = IRegistry(registry_);
+    }
 
     /***************************************
     POLICY VIEW FUNCTIONS
@@ -209,6 +205,14 @@ contract PolicyManager is ERC721Enhanced, IPolicyManager, Governable {
         return IPolicyDescriptor(_policyDescriptor).tokenURI(this, policyID);
     }
 
+   /**
+     * @notice Returns [`Registry`](./Registry) contract address.
+     * @return registry_ The `Registry` address.
+    */
+    function registry() external view override returns (address registry_) {
+        return address(_registry);
+    }
+
     /***************************************
     POLICY MUTATIVE FUNCTIONS
     ***************************************/
@@ -242,10 +246,11 @@ contract PolicyManager is ERC721Enhanced, IPolicyManager, Governable {
             riskStrategy: riskStrategy
         });
         policyID = ++_totalPolicyCount; // starts at 1
-        _activeCoverAmount += coverAmount;
-        _activeCoverAmountPerStrategy[riskStrategy] += coverAmount;
         _policyInfo[policyID] = info;
         _mint(policyholder, policyID);
+        // update active cover limit
+        IRiskManager(_registry.riskManager()).updateActiveCoverLimitForStrategy(riskStrategy, 0, coverAmount);
+
         emit PolicyCreated(policyID);
         return policyID;
     }
@@ -271,8 +276,10 @@ contract PolicyManager is ERC721Enhanced, IPolicyManager, Governable {
         external override tokenMustExist(policyID)
     {
         require(_policyInfo[policyID].product == msg.sender, "wrong product");
-        _activeCoverAmount = _activeCoverAmount - _policyInfo[policyID].coverAmount + coverAmount;
-        _activeCoverAmountPerStrategy[riskStrategy] = _activeCoverAmountPerStrategy[riskStrategy] - _policyInfo[policyID].coverAmount + coverAmount;
+       
+        // update active cover limit
+        IRiskManager(_registry.riskManager()).updateActiveCoverLimitForStrategy(riskStrategy, _policyInfo[policyID].coverAmount, coverAmount);
+        
         PolicyInfo memory info = PolicyInfo({
             product: msg.sender,
             positionDescription: positionDescription,
@@ -304,8 +311,9 @@ contract PolicyManager is ERC721Enhanced, IPolicyManager, Governable {
         external override tokenMustExist(policyID)
     {
         require(_policyInfo[policyID].product == msg.sender, "wrong product");
-        _activeCoverAmount = _activeCoverAmount - _policyInfo[policyID].coverAmount + coverAmount;
-        _activeCoverAmountPerStrategy[riskStrategy] = _activeCoverAmountPerStrategy[riskStrategy] - _policyInfo[policyID].coverAmount + coverAmount;
+
+        // update active cover limit
+        IRiskManager(_registry.riskManager()).updateActiveCoverLimitForStrategy(riskStrategy, _policyInfo[policyID].coverAmount, coverAmount);
         PolicyInfo memory info = PolicyInfo({
             product: msg.sender,
             positionDescription: _policyInfo[policyID].positionDescription,
@@ -334,8 +342,8 @@ contract PolicyManager is ERC721Enhanced, IPolicyManager, Governable {
      */
     function _burn(uint256 policyID) internal override {
         super._burn(policyID);
-        _activeCoverAmount -= _policyInfo[policyID].coverAmount;
-        _activeCoverAmountPerStrategy[_policyInfo[policyID].riskStrategy] -=  _policyInfo[policyID].coverAmount;
+        // update active cover limit
+        IRiskManager(_registry.riskManager()).updateActiveCoverLimitForStrategy(_policyInfo[policyID].riskStrategy, _policyInfo[policyID].coverAmount, 0);
         delete _policyInfo[policyID];
         emit PolicyBurned(policyID);
     }
@@ -345,7 +353,6 @@ contract PolicyManager is ERC721Enhanced, IPolicyManager, Governable {
      * @param policyIDs The list of expired policies.
      */
     function updateActivePolicies(uint256[] calldata policyIDs) external override {
-        uint256 activeCover = _activeCoverAmount;
 
         for(uint256 i = 0; i < policyIDs.length; i++) {
             uint256 policyID = policyIDs[i];
@@ -353,29 +360,15 @@ contract PolicyManager is ERC721Enhanced, IPolicyManager, Governable {
             if (policyHasExpired(policyID)) {
                 address product = _policyInfo[policyID].product;
                 uint256 coverAmount = _policyInfo[policyID].coverAmount;
-                activeCover -= coverAmount;
-                _activeCoverAmountPerStrategy[_policyInfo[policyID].riskStrategy] -= coverAmount;
+                // update active cover limit
+                IRiskManager(_registry.riskManager()).updateActiveCoverLimitForStrategy(_policyInfo[policyID].riskStrategy,_policyInfo[policyID].coverAmount,0);
                 IProduct(product).updateActiveCoverAmount(-SafeCast.toInt256(coverAmount));
                 super._burn(policyID);
             }
         }
-        _activeCoverAmount = activeCover;
     }
 
-    /**
-     * @notice Updates the active cover amount of the Soteria product.
-     * This function is only called by `SoteriaCoverageProduct` when a new policy is bought or updated.
-     * @param newCoverAmount The new cover amount.
-    */
-    function setSoteriaActiveCoverAmount(uint256 newCoverAmount) external override {
-        require(address(_soteriaCoverageProduct) != address(0x0), "no soteria product");
-        require(msg.sender == address(_soteriaCoverageProduct), "only soteria product");
-        uint256 coverAmount = _activeCoverAmount;
-        coverAmount = coverAmount + newCoverAmount - _activeCoverAmountPerStrategy[msg.sender];
-        _activeCoverAmountPerStrategy[msg.sender] = newCoverAmount;
-        _activeCoverAmount = coverAmount;
-        emit SoteriaProductCoverAmountUpdated(newCoverAmount);
-    }
+ 
 
     /***************************************
     PRODUCT VIEW FUNCTIONS
@@ -407,35 +400,6 @@ contract PolicyManager is ERC721Enhanced, IPolicyManager, Governable {
         return products.at(productNum);
     }
 
-    /**
-     * @notice Returns `SoteriaCoverageProduct`.
-     * @return soteria The address of soteria product.
-    */
-    function getSoteriaProduct() external override view returns (address soteria) {
-        return address(_soteriaCoverageProduct);
-    }
-
-    /***************************************
-    OTHER VIEW FUNCTIONS
-    ***************************************/
-
-    /**
-     * @notice Returns the current amount covered (in wei).
-     * @return amount The covered amount (in wei).
-    */
-    function activeCoverAmount() external view override returns (uint256 amount) {
-        return _activeCoverAmount;
-    }
-
-    /**
-     * @notice Returns the current amount covered (in wei).
-     * @param riskStrategy The risk strategy address.
-     * @return amount The covered amount (in wei).
-    */
-    function activeCoverAmountPerStrategy(address riskStrategy) external view override returns (uint256 amount) {
-        return _activeCoverAmountPerStrategy[riskStrategy];
-    }
-
     /***************************************
     GOVERNANCE FUNCTIONS
     ***************************************/
@@ -449,17 +413,6 @@ contract PolicyManager is ERC721Enhanced, IPolicyManager, Governable {
         require(product != address(0x0), "zero product");
         products.add(product);
         emit ProductAdded(product);
-    }
-
-    /**
-     * @notice Sets soteria product.
-     * Can only be called by the current [**governor**](/docs/protocol/governance).
-     * @param soteria The `SoteriaCoverageProduct`.
-     */
-     function setSoteriaProduct(address soteria) external override onlyGovernance {
-        require(soteria != address(0x0), "zero address soteria");
-        _soteriaCoverageProduct = ISoteriaCoverageProduct(soteria);
-        emit SoteriaProductSet(soteria);
     }
 
     /**
@@ -480,5 +433,16 @@ contract PolicyManager is ERC721Enhanced, IPolicyManager, Governable {
     function setPolicyDescriptor(address policyDescriptor_) external override onlyGovernance {
         _policyDescriptor = policyDescriptor_;
         emit PolicyDescriptorSet(policyDescriptor_);
+    }
+
+    /**
+     * @notice Sets the [`Registry`](./Registry) contract address.
+     * Can only be called by the current [**governor**](/docs/protocol/governance).
+     * @param registry_ The address of `Registry` contract.
+    */
+    function setRegistry(address registry_) external override onlyGovernance {
+        require(registry_ != address(0x0), "zero address registry");
+        _registry = IRegistry(registry_);
+        emit RegistrySet(registry_);
     }
 }

--- a/contracts/RiskManager.sol
+++ b/contracts/RiskManager.sol
@@ -5,7 +5,6 @@ import "./Governable.sol";
 import "./interface/ICoverageDataProvider.sol";
 import "./interface/IRegistry.sol";
 import "./interface/IProduct.sol";
-import "./interface/IPolicyManager.sol";
 import "./interface/IRiskManager.sol";
 
 /**
@@ -15,7 +14,7 @@ import "./interface/IRiskManager.sol";
  *
  * The total amount of sellable coverage is proportional to the assets in the [**risk backing capital pool**](./Vault). The max cover is split amongst products in a weighting system. [**Governance**](/docs/protocol/governance) can change these weights and with it each product's sellable cover.
  *
- * The minimum capital requirement is proportional to the amount of cover sold to [active policies](./PolicyManager).
+ * The minimum capital requirement is proportional to the amount of cover sold to active policies.
  *
  * Solace can use leverage to sell more cover than the available capital. The amount of leverage is stored as [`partialReservesFactor`](#partialreservesfactor) and is settable by [**governance**](/docs/protocol/governance).
  */
@@ -26,22 +25,28 @@ contract RiskManager is IRiskManager, Governable {
     ***************************************/
 
     /// @notice Holds mapping strategy => inddex.
-    mapping(address => uint256) internal _strategyToIndex;
+    mapping(address => uint256) private _strategyToIndex;
     /// @notice Holds mapping index => strategy.
-    mapping(uint256 => address) internal _indexToStrategy;
+    mapping(uint256 => address) private _indexToStrategy;
     /// @notice Holds strategies.
-    mapping(address => Strategy) internal _strategies;
+    mapping(address => Strategy) private _strategies;
+    /// @notice Returns true if the caller valid cover limit updater.
+    mapping(address => bool) public canUpdateCoverLimit;
+    // The current amount covered (in wei).
+    uint256 internal _activeCoverLimit;
+    /// @notice The current amount covered (in wei) per strategy;
+    mapping(address => uint256) internal _activeCoverLimitPerStrategy;
     /// @notice The total strategy count.
-    uint256 internal _strategyCount;
+    uint256 private _strategyCount;
     /// @notice The total weight sum of all strategies.
-    uint32 internal _weightSum;
+    uint32 private _weightSum;
     /// @notice Multiplier for minimum capital requirement in BPS.
-    uint16 internal _partialReservesFactor;
+    uint16 private _partialReservesFactor;
     /// @notice 10k basis points (100%).
-    uint16 internal constant MAX_BPS = 10000;
+    uint16 private constant MAX_BPS = 10000;
 
     /// @notice Registry contract.
-    IRegistry internal _registry;
+    IRegistry private _registry;
 
     /**
      * @notice Constructs the RiskManager contract.
@@ -52,10 +57,11 @@ contract RiskManager is IRiskManager, Governable {
         require(registry_ != address(0x0), "zero address registry");
         _registry = IRegistry(registry_);
         _partialReservesFactor = MAX_BPS;
+        canUpdateCoverLimit[_registry.policyManager()] = true;
     }
 
     /***************************************
-    RISK STRATEGY FUNCTIONS
+    RISK MANAGER MUTUATOR FUNCTIONS
     ***************************************/
 
     /**
@@ -112,6 +118,49 @@ contract RiskManager is IRiskManager, Governable {
         emit StrategyStatusUpdated(strategy_, status_);
     }
 
+   /**
+     * @notice Updates the active cover limit amount for the given strategy. 
+     * This function is only called by valid requesters when a new policy is bought or updated.
+     * @dev The policy manager and soteria will call this function for now.
+     * @param strategy The strategy address to add cover limit.
+     * @param currentCoverLimit The current cover limit amount of the strategy's product.
+     * @param newCoverLimit The new cover limit amount of the strategy's product.
+    */
+    function updateActiveCoverLimitForStrategy(address strategy, uint256 currentCoverLimit, uint256 newCoverLimit) external override {
+        require(canUpdateCoverLimit[msg.sender], "unauthorized caller");
+        require(strategyIsActive(strategy), "inactive strategy");
+        uint256 oldCoverLimitOfStrategy = _activeCoverLimitPerStrategy[strategy];
+        _activeCoverLimit = _activeCoverLimit - currentCoverLimit + newCoverLimit;
+        uint256 newCoverLimitOfStrategy = oldCoverLimitOfStrategy - currentCoverLimit + newCoverLimit;
+        _activeCoverLimitPerStrategy[strategy] = newCoverLimitOfStrategy;
+        emit ActiveCoverLimitUpdated(strategy, oldCoverLimitOfStrategy, newCoverLimitOfStrategy);
+    }
+
+    /**
+     * @notice Adds new address to allow updating cover limit amounts.
+     * Can only be called by the current [**governor**](/docs/protocol/governance).
+     * @param updater The address that can update cover limit.
+    */
+    function addCoverLimitUpdater(address updater) external override onlyGovernance {
+        require(updater != address(0x0), "zero address coverlimit updater");
+        canUpdateCoverLimit[updater] = true;
+        emit CoverLimitUpdaterAdded(updater);
+    }
+
+    /**
+     * @notice Removes the cover limit updater.
+     * @param updater The address of updater to remove.
+    */
+    function removeCoverLimitUpdater(address updater) external override onlyGovernance {
+        require(updater != address(0x0), "zero address coverlimit updater");
+        delete canUpdateCoverLimit[updater];
+        emit CoverLimitUpdaterDeleted(updater);
+    }
+
+    /***************************************
+    RISK MANAGER VIEW FUNCTIONS
+    ***************************************/
+
     /**
      * @notice Checks if the given risk strategy is active.
      * @param strategy_ The risk strategy.
@@ -163,10 +212,6 @@ contract RiskManager is IRiskManager, Governable {
         return strategy.weight;
     }
 
-    /***************************************
-    RISK MANAGER VIEW FUNCTIONS
-    ***************************************/
-
     /**
      * @notice The maximum amount of cover that Solace as a whole can sell.
      * @return cover The max amount of cover in wei.
@@ -194,6 +239,23 @@ contract RiskManager is IRiskManager, Governable {
         return _weightSum == 0 ? type(uint32).max : _weightSum;
     }
 
+    /**
+     * @notice Returns the current amount covered (in wei).
+     * @return amount The covered amount (in wei).
+    */
+    function activeCoverLimit() public view override returns (uint256 amount) {
+        return _activeCoverLimit;
+    }
+
+    /**
+     * @notice Returns the current amount covered (in wei).
+     * @param riskStrategy The risk strategy address.
+     * @return amount The covered amount (in wei).
+    */
+    function activeCoverLimitPerStrategy(address riskStrategy) public view override returns (uint256 amount) {
+        return _activeCoverLimitPerStrategy[riskStrategy];
+    }
+
     /***************************************
     MIN CAPITAL VIEW FUNCTIONS
     ***************************************/
@@ -203,7 +265,7 @@ contract RiskManager is IRiskManager, Governable {
      * @return mcr The minimum capital requirement.
      */
     function minCapitalRequirement() external view override returns (uint256 mcr) {
-        return IPolicyManager(_registry.policyManager()).activeCoverAmount() * _partialReservesFactor / MAX_BPS;
+        return activeCoverLimit() * _partialReservesFactor / MAX_BPS;
     }
 
     /**
@@ -214,7 +276,7 @@ contract RiskManager is IRiskManager, Governable {
      * @return smcr The strategy minimum capital requirement.
      */
     function minCapitalRequirementPerStrategy(address strategy) public view override returns (uint256 smcr) {
-        return IPolicyManager(_registry.policyManager()).activeCoverAmountPerStrategy(strategy) * _partialReservesFactor / MAX_BPS;
+        return activeCoverLimitPerStrategy(strategy) * _partialReservesFactor / MAX_BPS;
     }
 
     /**

--- a/contracts/interface/IPolicyManager.sol
+++ b/contracts/interface/IPolicyManager.sol
@@ -221,7 +221,7 @@ interface IPolicyManager is IERC721Enhanced {
      * This function is only called by `SoteriaCoverageProduct` when a new policy is bought or updated.
      * @param newCoverAmount The new cover amount.
     */ 
-    function setSoteriaActiveCoverLimit(uint256 newCoverAmount) external; 
+    function setSoteriaActiveCoverAmount(uint256 newCoverAmount) external; 
 
     /***************************************
     PRODUCT VIEW FUNCTIONS

--- a/contracts/interface/IPolicyManager.sol
+++ b/contracts/interface/IPolicyManager.sol
@@ -221,7 +221,7 @@ interface IPolicyManager is IERC721Enhanced {
      * This function is only called by `SoteriaCoverageProduct` when a new policy is bought or updated.
      * @param newCoverAmount The new cover amount.
     */ 
-    function setSoteriaActiveCoverAmount(uint256 newCoverAmount) external; 
+    function setSoteriaActiveCoverLimit(uint256 newCoverAmount) external; 
 
     /***************************************
     PRODUCT VIEW FUNCTIONS

--- a/contracts/interface/IPolicyManager.sol
+++ b/contracts/interface/IPolicyManager.sol
@@ -30,10 +30,8 @@ interface IPolicyManager is IERC721Enhanced {
     event ProductAdded(address product);
     /// @notice Emitted when a new product is removed.
     event ProductRemoved(address product);
-    /// @notice Emitted when soteria product is set.
-    event SoteriaProductSet(address soteria);
-    /// @notice Emitted when soteria active cover amount is updated.
-    event SoteriaProductCoverAmountUpdated(uint256 newCoverAmount);
+    /// @notice Emitted when registry is set.
+    event RegistrySet(address registry);
 
     /***************************************
     POLICY VIEW FUNCTIONS
@@ -155,6 +153,12 @@ interface IPolicyManager is IERC721Enhanced {
 
     /// @notice The address of the [`PolicyDescriptor`](./PolicyDescriptor) contract.
     function policyDescriptor() external view returns (address);
+   
+    /**
+     * @notice Returns [`Registry`](./Registry) contract address.
+     * @return registry_ The `Registry` address.
+    */
+    function registry() external view returns (address registry_);
 
     /***************************************
     POLICY MUTATIVE FUNCTIONS
@@ -216,13 +220,6 @@ interface IPolicyManager is IERC721Enhanced {
      */
     function updateActivePolicies(uint256[] calldata policyIDs) external;
 
-    /**
-     * @notice Updates the active cover amount of the Soteria product.
-     * This function is only called by `SoteriaCoverageProduct` when a new policy is bought or updated.
-     * @param newCoverAmount The new cover amount.
-    */ 
-    function setSoteriaActiveCoverAmount(uint256 newCoverAmount) external; 
-
     /***************************************
     PRODUCT VIEW FUNCTIONS
     ***************************************/
@@ -247,29 +244,6 @@ interface IPolicyManager is IERC721Enhanced {
      */
     function getProduct(uint256 productNum) external view returns (address product);
 
-    /**
-     * @notice Returns `SoteriaCoverageProduct`.
-     * @return soteria The address of soteria product.
-    */
-    function getSoteriaProduct() external view returns (address soteria);
-
-    /***************************************
-    OTHER VIEW FUNCTIONS
-    ***************************************/
-
-    /**
-     * @notice Returns the current amount covered (in wei).
-     * @return amount The covered amount (in wei).
-    */
-    function activeCoverAmount() external view returns (uint256 amount);
-
-    /**
-     * @notice Returns the current amount covered (in wei).
-     * @param riskStrategy The risk strategy address.
-     * @return amount The covered amount (in wei).
-    */
-    function activeCoverAmountPerStrategy(address riskStrategy) external view returns (uint256 amount);
-
     /***************************************
     GOVERNANCE FUNCTIONS
     ***************************************/
@@ -282,19 +256,11 @@ interface IPolicyManager is IERC721Enhanced {
     function addProduct(address product) external;
 
     /**
-     * @notice Sets soteria product.
-     * Can only be called by the current [**governor**](/docs/protocol/governance).
-     * @param soteria The `SoteriaCoverageProduct`.
-     */
-    function setSoteriaProduct(address soteria) external; 
-
-    /**
      * @notice Removes a product.
      * Can only be called by the current [**governor**](/docs/protocol/governance).
      * @param product the product to remove
      */
     function removeProduct(address product) external;
-
 
     /**
      * @notice Set the token descriptor.
@@ -302,4 +268,11 @@ interface IPolicyManager is IERC721Enhanced {
      * @param policyDescriptor The new token descriptor address.
      */
     function setPolicyDescriptor(address policyDescriptor) external;
+
+    /**
+     * @notice Sets the [`Registry`](./Registry) contract address.
+     * Can only be called by the current [**governor**](/docs/protocol/governance).
+     * @param registry_ The address of `Registry` contract.
+    */
+    function setRegistry(address registry_) external;
 }

--- a/contracts/interface/IRiskManager.sol
+++ b/contracts/interface/IRiskManager.sol
@@ -53,8 +53,17 @@ interface IRiskManager {
     /// @notice Emitted when the partial reserves factor is set.
     event PartialReservesFactorSet(uint16 partialReservesFactor);
 
+    /// @notice Emitted when the cover limit amount of the strategy is updated.
+    event ActiveCoverLimitUpdated(address strategy, uint256 oldCoverLimit, uint256 newCoverLimit);
+
+    /// @notice Emitted when the cover limit updater is set.
+    event CoverLimitUpdaterAdded(address updater);
+
+    /// @notice Emitted when the cover limit updater is removed.
+    event CoverLimitUpdaterDeleted(address updater);
+
     /***************************************
-    RISK STRATEGY FUNCTIONS
+    RISK MANAGER MUTUTATOR FUNCTIONS
     ***************************************/
 
     /**
@@ -64,21 +73,6 @@ interface IRiskManager {
      * @return index The index of the risk strategy.
     */
     function addRiskStrategy(address strategy_) external returns (uint256 index);
-
-    /**
-     * @notice Checks is an address is an active strategy.
-     * @param strategy_ The risk strategy.
-     * @return status True if the strategy is active.
-    */
-    function strategyIsActive(address strategy_) external view returns (bool status);
-
-     /**
-      * @notice Return the strategy at an index.
-      * @dev Enumerable `[1, numStrategies]`.
-      * @param index_ Index to query.
-      * @return strategy The product address.
-    */
-    function strategyAt(uint256 index_) external view returns (address strategy);
 
     /**
      * @notice Sets the weight of the `Risk Strategy`.
@@ -95,6 +89,48 @@ interface IRiskManager {
      * @param status_ The status to set.
     */
     function setStrategyStatus(address strategy_, uint8 status_) external;
+
+   /**
+     * @notice Updates the active cover limit amount for the given strategy. 
+     * This function is only called by valid requesters when a new policy is bought or updated.
+     * @dev The policy manager and soteria will call this function for now.
+     * @param strategy The strategy address to add cover limit.
+     * @param currentCoverLimit The current cover limit amount of the strategy's product.
+     * @param newCoverLimit The new cover limit amount of the strategy's product.
+    */
+    function updateActiveCoverLimitForStrategy(address strategy, uint256 currentCoverLimit, uint256 newCoverLimit) external;
+
+    /**
+     * @notice Adds new address to allow updating cover limit amounts.
+     * Can only be called by the current [**governor**](/docs/protocol/governance).
+     * @param updater The address that can update cover limit.
+    */
+    function addCoverLimitUpdater(address updater) external ;
+
+    /**
+     * @notice Removes the cover limit updater.
+     * @param updater The address of updater to remove.
+    */
+    function removeCoverLimitUpdater(address updater) external;
+
+    /***************************************
+    RISK MANAGER VIEW FUNCTIONS
+    ***************************************/
+
+    /**
+     * @notice Checks is an address is an active strategy.
+     * @param strategy_ The risk strategy.
+     * @return status True if the strategy is active.
+    */
+    function strategyIsActive(address strategy_) external view returns (bool status);
+
+     /**
+      * @notice Return the strategy at an index.
+      * @dev Enumerable `[1, numStrategies]`.
+      * @param index_ Index to query.
+      * @return strategy The product address.
+    */
+    function strategyAt(uint256 index_) external view returns (address strategy);
 
     /**
      * @notice Returns the number of registered strategies..
@@ -125,6 +161,19 @@ interface IRiskManager {
      * @return cover The max amount of cover in wei.
      */
     function maxCoverPerStrategy(address strategy_) external view returns (uint256 cover);
+
+    /**
+     * @notice Returns the current amount covered (in wei).
+     * @return amount The covered amount (in wei).
+    */
+    function activeCoverLimit() external view returns (uint256 amount);
+
+    /**
+     * @notice Returns the current amount covered (in wei).
+     * @param riskStrategy The risk strategy address.
+     * @return amount The covered amount (in wei).
+    */
+    function activeCoverLimitPerStrategy(address riskStrategy) external view returns (uint256 amount);
 
     /***************************************
     MAX COVER VIEW FUNCTIONS

--- a/contracts/interface/ISoteriaCoverageProduct.sol
+++ b/contracts/interface/ISoteriaCoverageProduct.sol
@@ -16,8 +16,8 @@ interface ISoteriaCoverageProduct {
     /// @notice Emitted when a Policy is closed.
     event PolicyClosed(uint256 policyID);
 
-    /// @notice Emitted when a Policy ic canceled.
-    event PolicyCanceled(uint256 policyID);
+    /// @notice Emitted when a Policy ic deactivated.
+    event PolicyDeactivated(uint256 policyID);
 
     /// @notice Emitted when Registry address is updated.
     event RegistrySet(address registry);
@@ -40,17 +40,11 @@ interface ISoteriaCoverageProduct {
     /// @notice Emitted when policy manager cover amount for soteria is updated.
     event PolicyManagerUpdated(uint256 activeCoverLimit);
 
-    /// @notice Emitted when a claim signer is added.
-    event SignerAdded(address signer);
-
-    /// @notice Emitted when a claim signer is removed.
-    event SignerRemoved(address signer);
-
-    /// @notice Emitted when reward balance is gifted.
+    /// @notice Emitted when maxChargeablePremium is set.
     event MaxChargeablePremiumSet(uint256 maxChargeablePremium);
 
-    /// @notice Emitted when reward balance is gifted.
-    event RewardBalanceGifted(address policyholder, uint256 amountGifted);
+    /// @notice Emitted when reward points are gifted.
+    event RewardPointsGifted(address policyholder, uint256 amountGifted);
 
     /***************************************
     POLICY FUNCTIONS
@@ -91,12 +85,12 @@ interface ISoteriaCoverageProduct {
     function chargePremiums(address[] calldata holders_, uint256[] calldata premiums_) external payable;
 
     /**
-     * @notice Cancel and burn a policy.
+     * @notice Deactivate and burn a policy.
      * User will receive their deposited funds.
      * Can only be called by the policyholder.
      * @param policyID_ The ID of the policy.
     */
-    function cancelPolicy(uint256 policyID_) external;
+    function deactivatePolicy(uint256 policyID_) external;
 
     /***************************************
     VIEW FUNCTIONS
@@ -109,11 +103,11 @@ interface ISoteriaCoverageProduct {
     function newCoverCapacity() external view returns (uint256 newCoverCapacity_);
 
     /**
-    * @notice Return reward balance for a policyholder.
+    * @notice Return reward points for a policyholder.
     * @param policyholder_ The address of the policyholder.
-    * @return rewardBalance_ The reward balance for a policyholder.
+    * @return rewardPoints_ The reward points for a policyholder.
     */
-    function rewardBalanceOf(address policyholder_) external view returns (uint256 rewardBalance_);
+    function rewardPointsOf(address policyholder_) external view returns (uint256 rewardPoints_);
 
     /**
      * @notice Returns the policyholder fund amount.
@@ -184,13 +178,6 @@ interface ISoteriaCoverageProduct {
      * @return amount The cover amount for given policy.
     */
     function coverLimitOf(uint256 policy_) external view returns (uint256 amount);
-
-    /**
-     * @notice Returns true if the given account is authorized to sign claims.
-     * @param account_ Potential signer to query.
-     * @return status True if is authorized signer.
-    */
-    function isAuthorizedSigner(address account_) external view returns (bool status);
     
     /***************************************
     GOVERNANCE FUNCTIONS
@@ -205,25 +192,11 @@ interface ISoteriaCoverageProduct {
 
     /**
      * @notice Pauses or unpauses buying and extending policies.
-     * Cancelling policies and submitting claims are unaffected by pause.
+     * Deactivating policies are unaffected by pause.
      * Can only be called by the current [**governor**](/docs/protocol/governance).
      * @param paused_ True to pause, false to unpause.
     */
     function setPaused(bool paused_) external;
-
-    /**
-     * @notice Adds a new signer that can authorize claims.
-     * Can only be called by the current [**governor**](/docs/protocol/governance).
-     * @param signer_ The signer to add.
-    */
-    function addSigner(address signer_) external;
-    
-    /**
-     * @notice Removes a signer.
-     * Can only be called by the current [**governor**](/docs/protocol/governance).
-     * @param signer_ The signer to remove.
-    */
-    function removeSigner(address signer_) external;
 
     /**
      * @notice set _maxChargeablePremium.
@@ -235,8 +208,8 @@ interface ISoteriaCoverageProduct {
     /**
      * @notice Enables governance to gift 'free' cover to specific addresses.
      * Can only be called by the current [**governor**](/docs/protocol/governance).
-     * @param policyholder_ The policy holder to gift reward balance to.
-     * @param amountRewardBalanceGift_ Amount of reward balance to gift.
+     * @param policyholder_ The policy holder to gift reward points to.
+     * @param pointsToGift_ Amount of reward points to gift.
     */
-    function giftRewardBalance(address policyholder_, uint256 amountRewardBalanceGift_) external;
+    function giftRewardPoints(address policyholder_, uint256 pointsToGift_) external;
 }

--- a/contracts/interface/ISoteriaCoverageProduct.sol
+++ b/contracts/interface/ISoteriaCoverageProduct.sol
@@ -40,8 +40,11 @@ interface ISoteriaCoverageProduct {
     /// @notice Emitted when policy manager cover amount for soteria is updated.
     event PolicyManagerUpdated(uint256 activeCoverLimit);
 
-    /// @notice Emitted when maxChargeablePremium is set.
-    event MaxChargeablePremiumSet(uint256 maxChargeablePremium);
+    /// @notice Emitted when maxRate is set.
+    event MaxRateSet(uint256 maxRate);
+
+    /// @notice Emitted when chargeCycle is set.
+    event ChargeCycleSet(uint256 chargeCycle);
 
     /// @notice Emitted when reward points are gifted.
     event RewardPointsGifted(address policyholder, uint256 amountGifted);
@@ -78,13 +81,6 @@ interface ISoteriaCoverageProduct {
     function updateCoverLimit(uint256 policyID_, uint256 newCoverLimit_) external;
 
     /**
-     * @notice Charge premiums for each policy holder.
-     * @param holders_ The policy holders.
-     * @param premiums_ The premium amounts in `wei` per policy holder.
-    */
-    function chargePremiums(address[] calldata holders_, uint256[] calldata premiums_) external payable;
-
-    /**
      * @notice Deactivate and burn a policy.
      * User will receive their deposited funds.
      * Can only be called by the policyholder.
@@ -98,9 +94,9 @@ interface ISoteriaCoverageProduct {
 
     /**
     * @notice Determine available capacity for new cover.
-    * @return newCoverCapacity_ The amount of available capacity for new cover.
+    * @return availableCoverCapacity_ The amount of available capacity for new cover.
     */
-    function newCoverCapacity() external view returns (uint256 newCoverCapacity_);
+    function availableCoverCapacity() external view returns (uint256 availableCoverCapacity_);
 
     /**
     * @notice Return reward points for a policyholder.
@@ -114,7 +110,7 @@ interface ISoteriaCoverageProduct {
      * @param policyholder_ The address of the policyholder.
      * @return amount The amount of funds.    
     */
-    function soteriaAccountBalance(address policyholder_) external view returns (uint256 amount);
+    function accountBalanceOf(address policyholder_) external view returns (uint256 amount);
    
     /**
      * @notice Returns the policyholder's policy id.
@@ -155,10 +151,10 @@ interface ISoteriaCoverageProduct {
     function paused() external view returns (bool status);
 
     /**
-     * @notice Returns active cover amount in `wei`.
-     * @return amount The active cover amount.
+     * @notice Returns active cover limit in `wei`.
+     * @return amount The active cover limit.
     */
-    function totalActiveCover() external view returns (uint256 amount);
+    function activeCoverLimit() external view returns (uint256 amount);
 
     /**
      * @notice Returns the policy count.
@@ -167,10 +163,16 @@ interface ISoteriaCoverageProduct {
     function policyCount() external view returns (uint256 count);
 
     /**
-     * @notice Returns the max chargeable premium.
-     * @return maxChargeablePremium_ the max chargeable premium.
+     * @notice Returns the max rate.
+     * @return maxRate_ the max rate.
     */
-    function maxChargeablePremium() external view returns (uint256 maxChargeablePremium_);
+    function maxRate() external view returns (uint256 maxRate_);
+
+    /**
+     * @notice Returns the charge cycle duration.
+     * @return chargeCycle_ the charge cycle duration.
+    */
+    function chargeCycle() external view returns (uint256 chargeCycle_);
 
     /**
      * @notice Returns cover amount of given policy id.
@@ -199,11 +201,18 @@ interface ISoteriaCoverageProduct {
     function setPaused(bool paused_) external;
 
     /**
-     * @notice set _maxChargeablePremium.
+     * @notice set _maxRatePremium.
      * Can only be called by the current [**governor**](/docs/protocol/governance).
-     * @param maxChargeablePremium_ Desired maxChargeablePremium.
+     * @param maxRate_ Desired maxRate.
     */
-    function setMaxChargeablePremium(uint256 maxChargeablePremium_) external;
+    function setMaxRate(uint256 maxRate_) external;
+
+    /**
+     * @notice set _chargeCycle.
+     * Can only be called by the current [**governor**](/docs/protocol/governance).
+     * @param chargeCycle_ Desired chargeCycle.
+    */
+    function setChargeCycle(uint256 chargeCycle_) external;
 
     /**
      * @notice Enables governance to gift 'free' cover to specific addresses.
@@ -212,4 +221,11 @@ interface ISoteriaCoverageProduct {
      * @param pointsToGift_ Amount of reward points to gift.
     */
     function giftRewardPoints(address policyholder_, uint256 pointsToGift_) external;
+
+    /**
+     * @notice Charge premiums for each policy holder.
+     * @param holders_ The policy holders.
+     * @param premiums_ The premium amounts in `wei` per policy holder.
+    */
+    function chargePremiums(address[] calldata holders_, uint256[] calldata premiums_) external payable;
 }

--- a/contracts/interface/ISoteriaCoverageProduct.sol
+++ b/contracts/interface/ISoteriaCoverageProduct.sol
@@ -37,8 +37,11 @@ interface ISoteriaCoverageProduct {
     /// @notice Emitted when policy manager cover amount for soteria is updated.
     event PolicyManagerUpdated(uint256 activeCoverLimit);
 
-    /// @notice Emitted when maxRate is set.
-    event MaxRateSet(uint256 maxRate);
+    /// @notice Emitted when maxRateNum is set.
+    event MaxRateNumSet(uint256 maxRateNum);
+
+    /// @notice Emitted when maxRateDenom is set.
+    event MaxRateDenomSet(uint256 maxRateDenom);
 
     /// @notice Emitted when chargeCycle is set.
     event ChargeCycleSet(uint256 chargeCycle);
@@ -160,11 +163,16 @@ interface ISoteriaCoverageProduct {
     function policyCount() external view returns (uint256 count);
 
     /**
-     * @notice Returns the max rate.
-     * @return maxRate_ the max rate.
+     * @notice Returns the max rate numerator.
+     * @return maxRateNum_ the max rate numerator.
     */
-    function maxRate() external view returns (uint256 maxRate_);
+    function maxRateNum() external view returns (uint256 maxRateNum_);
 
+    /**
+     * @notice Returns the max rate denominator.
+     * @return maxRateDenom_ the max rate denominator.
+    */
+    function maxRateDenom() external view returns (uint256 maxRateDenom_);
     /**
      * @notice Returns the charge cycle duration.
      * @return chargeCycle_ the charge cycle duration.
@@ -198,11 +206,18 @@ interface ISoteriaCoverageProduct {
     function setPaused(bool paused_) external;
 
     /**
-     * @notice set _maxRatePremium.
+     * @notice set _maxRateNum.
      * Can only be called by the current [**governor**](/docs/protocol/governance).
-     * @param maxRate_ Desired maxRate.
+     * @param maxRateNum_ Desired maxRateNum.
     */
-    function setMaxRate(uint256 maxRate_) external;
+    function setMaxRateNum(uint256 maxRateNum_) external;
+
+    /**
+     * @notice set _maxRateDenom.
+     * Can only be called by the current [**governor**](/docs/protocol/governance).
+     * @param maxRateDenom_ Desired maxRateDenom.
+    */
+    function setMaxRateDenom(uint256 maxRateDenom_) external;
 
     /**
      * @notice set _chargeCycle.

--- a/contracts/interface/ISoteriaCoverageProduct.sol
+++ b/contracts/interface/ISoteriaCoverageProduct.sol
@@ -13,7 +13,7 @@ interface ISoteriaCoverageProduct {
     /// @notice Emitted when a Policy is updated.
     event PolicyUpdated(uint256 policyID);
 
-    /// @notice Emitted when a Policy ic deactivated.
+    /// @notice Emitted when a Policy is deactivated.
     event PolicyDeactivated(uint256 policyID);
 
     /// @notice Emitted when Registry address is updated.
@@ -81,12 +81,11 @@ interface ISoteriaCoverageProduct {
     function updateCoverLimit(uint256 policyID_, uint256 newCoverLimit_) external;
 
     /**
-     * @notice Deactivate and burn a policy.
-     * User will receive their deposited funds.
-     * Can only be called by the policyholder.
-     * @param policyID_ The ID of the policy.
-    */
-    function deactivatePolicy(uint256 policyID_) external;
+     * @notice Deactivate a user's own policy.
+     * @param policyID_ The policy ID to update.
+     * User will receive their entire Soteria account balance.
+     */
+     function deactivatePolicy(uint256 policyID_) external;
 
     /***************************************
     VIEW FUNCTIONS

--- a/contracts/interface/ISoteriaCoverageProduct.sol
+++ b/contracts/interface/ISoteriaCoverageProduct.sol
@@ -19,8 +19,23 @@ interface ISoteriaCoverageProduct {
     /// @notice Emitted when Registry address is updated.
     event RegistrySet(address registry);
 
+    /// @notice Emitted when Premium Pool address is updated.
+    event PremiumPoolSet(address premiumPool);
+
+    /// @notice Emitted when Premium Collector address is updated.
+    event PremiumCollectorSet(address premiumCollector);
+
     /// @notice Emitted when pause is set.
     event PauseSet(bool pause);
+
+    /// @notice Emitted when a user enters cooldown mode.
+    event CooldownStarted(address policyholder, uint256 startTime);
+
+    /// @notice Emitted when a user leaves cooldown mode.
+    event CooldownStopped(address policyholder);
+
+    /// @notice Emitted when the cooldown period is set.
+    event CooldownPeriodSet(uint256 cooldownPeriod);
 
     /// @notice Emitted when a deposit is made.
     event DepositMade(address from, uint256 amount);
@@ -33,6 +48,9 @@ interface ISoteriaCoverageProduct {
 
     /// @notice Emitted when premium is partially charged.
     event PremiumPartiallyCharged(address policyholder, uint256 actualPremium, uint256 chargedPremium);
+
+    /// @notice Emitted when policy manager cover amount for soteria is updated.
+    event PolicyManagerUpdated(uint256 activeCoverLimit);
 
     /// @notice Emitted when maxRateNum is set.
     event MaxRateNumSet(uint256 maxRateNum);
@@ -72,17 +90,15 @@ interface ISoteriaCoverageProduct {
 
     /**
      * @notice Updates the cover amount of the policy.
-     * @param policyID_ The policy ID to update.
      * @param newCoverLimit_ The new value to cover in **ETH**.
     */
-    function updateCoverLimit(uint256 policyID_, uint256 newCoverLimit_) external;
+    function updateCoverLimit(uint256 newCoverLimit_) external;
 
     /**
      * @notice Deactivate a user's own policy.
-     * @param policyID_ The policy ID to update.
      * User will receive their entire Soteria account balance.
      */
-     function deactivatePolicy(uint256 policyID_) external;
+     function deactivatePolicy() external;
 
     /***************************************
     VIEW FUNCTIONS
@@ -141,6 +157,18 @@ interface ISoteriaCoverageProduct {
     function riskManager() external view returns (address riskManager_);
 
     /**
+     * @notice Returns Premium Pool contract address.
+     * @return premiumPool_ The Premium Pool address.
+    */
+    function premiumPool() external view returns (address premiumPool_);
+
+    /**
+     * @notice Returns Premium Collector contract address.
+     * @return premiumCollector_ The Premium Collector address.
+    */
+    function premiumCollector() external view returns (address premiumCollector_);
+
+    /**
      * @notice Returns whether or not product is currently in paused state.
      * @return status True if product is paused.
     */
@@ -181,7 +209,20 @@ interface ISoteriaCoverageProduct {
      * @return amount The cover amount for given policy.
     */
     function coverLimitOf(uint256 policy_) external view returns (uint256 amount);
-    
+
+    /**
+     * @notice The minimum amount of time a user must wait to withdraw funds.
+     * @return cooldownPeriod_ The cooldown period in seconds.
+     */
+    function cooldownPeriod() external view returns (uint256 cooldownPeriod_);
+
+    /**
+     * @notice The timestamp that a depositor's cooldown started.
+     * @param policyholder_ The policy holder
+     * @return cooldownStart_ The cooldown period start expressed as Unix timestamp
+     */
+    function cooldownStart(address policyholder_) external view returns (uint256 cooldownStart_);
+
     /***************************************
     GOVERNANCE FUNCTIONS
     ***************************************/
@@ -194,12 +235,29 @@ interface ISoteriaCoverageProduct {
     function setRegistry(address registry_) external;
 
     /**
+     * @notice Sets the Premium Pool contract address.
+    */
+    function setPremiumPool(address premiumPool_) external;
+
+    /**
+     * @notice Sets the Premium Collector contract address.
+    */
+    function setPremiumCollector(address premiumCollector_) external;
+
+    /**
      * @notice Pauses or unpauses buying and extending policies.
      * Deactivating policies are unaffected by pause.
      * Can only be called by the current [**governor**](/docs/protocol/governance).
      * @param paused_ True to pause, false to unpause.
     */
     function setPaused(bool paused_) external;
+
+    /**
+     * @notice Sets the cooldown period that a user must wait after deactivating their policy, to withdraw funds from their Soteria account.
+     * Can only be called by the current [**governor**](/docs/protocol/governance).
+     * @param cooldownPeriod_ Cooldown period in seconds.
+     */
+    function setCooldownPeriod(uint256 cooldownPeriod_) external;
 
     /**
      * @notice set _maxRateNum.

--- a/contracts/interface/ISoteriaCoverageProduct.sol
+++ b/contracts/interface/ISoteriaCoverageProduct.sol
@@ -34,9 +34,6 @@ interface ISoteriaCoverageProduct {
     /// @notice Emitted when premium is partially charged.
     event PremiumPartiallyCharged(address policyholder, uint256 actualPremium, uint256 chargedPremium);
 
-    /// @notice Emitted when policy manager cover amount for soteria is updated.
-    event PolicyManagerUpdated(uint256 activeCoverLimit);
-
     /// @notice Emitted when maxRateNum is set.
     event MaxRateNumSet(uint256 maxRateNum);
 

--- a/contracts/interface/ISoteriaCoverageProduct.sol
+++ b/contracts/interface/ISoteriaCoverageProduct.sol
@@ -46,8 +46,8 @@ interface ISoteriaCoverageProduct {
     /// @notice Emitted when chargeCycle is set.
     event ChargeCycleSet(uint256 chargeCycle);
 
-    /// @notice Emitted when reward points are gifted.
-    event RewardPointsGifted(address policyholder, uint256 amountGifted);
+    /// @notice Emitted when reward points are set.
+    event RewardPointsSet(address policyholder, uint256 amountGifted);
 
     /***************************************
     POLICY FUNCTIONS
@@ -117,7 +117,7 @@ interface ISoteriaCoverageProduct {
      * @param policyholder_ The address of the policyholder.
      * @return policyID The policy id.
     */
-    function policyIDOf(address policyholder_) external view returns (uint256 policyID);
+    function policyOf(address policyholder_) external view returns (uint256 policyID);
 
     /**
      * @notice Returns whether if the policy is active or not.
@@ -215,12 +215,12 @@ interface ISoteriaCoverageProduct {
     function setChargeCycle(uint256 chargeCycle_) external;
 
     /**
-     * @notice Enables governance to gift 'free' cover to specific addresses.
+     * @notice Enables governance to gift (and remove) 'free' cover to specific addresses.
      * Can only be called by the current [**governor**](/docs/protocol/governance).
-     * @param policyholder_ The policy holder to gift reward points to.
-     * @param pointsToGift_ Amount of reward points to gift.
+     * @param policyholder_ The policy holder to set reward points for.
+     * @param rewardPoints_ Desired amount of reward points.
     */
-    function giftRewardPoints(address policyholder_, uint256 pointsToGift_) external;
+    function setRewardPoints(address policyholder_, uint256 rewardPoints_) external;
 
     /**
      * @notice Charge premiums for each policy holder.

--- a/contracts/interface/ISoteriaCoverageProduct.sol
+++ b/contracts/interface/ISoteriaCoverageProduct.sol
@@ -13,9 +13,6 @@ interface ISoteriaCoverageProduct {
     /// @notice Emitted when a Policy is updated.
     event PolicyUpdated(uint256 policyID);
 
-    /// @notice Emitted when a Policy is closed.
-    event PolicyClosed(uint256 policyID);
-
     /// @notice Emitted when a Policy ic deactivated.
     event PolicyDeactivated(uint256 policyID);
 

--- a/contracts/interface/ISoteriaCoverageProduct.sol
+++ b/contracts/interface/ISoteriaCoverageProduct.sol
@@ -19,23 +19,8 @@ interface ISoteriaCoverageProduct {
     /// @notice Emitted when Registry address is updated.
     event RegistrySet(address registry);
 
-    /// @notice Emitted when Premium Pool address is updated.
-    event PremiumPoolSet(address premiumPool);
-
-    /// @notice Emitted when Premium Collector address is updated.
-    event PremiumCollectorSet(address premiumCollector);
-
     /// @notice Emitted when pause is set.
     event PauseSet(bool pause);
-
-    /// @notice Emitted when a user enters cooldown mode.
-    event CooldownStarted(address policyholder, uint256 startTime);
-
-    /// @notice Emitted when a user leaves cooldown mode.
-    event CooldownStopped(address policyholder);
-
-    /// @notice Emitted when the cooldown period is set.
-    event CooldownPeriodSet(uint256 cooldownPeriod);
 
     /// @notice Emitted when a deposit is made.
     event DepositMade(address from, uint256 amount);
@@ -90,15 +75,17 @@ interface ISoteriaCoverageProduct {
 
     /**
      * @notice Updates the cover amount of the policy.
+     * @param policyID_ The policy ID to update.
      * @param newCoverLimit_ The new value to cover in **ETH**.
     */
-    function updateCoverLimit(uint256 newCoverLimit_) external;
+    function updateCoverLimit(uint256 policyID_, uint256 newCoverLimit_) external;
 
     /**
      * @notice Deactivate a user's own policy.
+     * @param policyID_ The policy ID to update.
      * User will receive their entire Soteria account balance.
      */
-     function deactivatePolicy() external;
+     function deactivatePolicy(uint256 policyID_) external;
 
     /***************************************
     VIEW FUNCTIONS
@@ -157,18 +144,6 @@ interface ISoteriaCoverageProduct {
     function riskManager() external view returns (address riskManager_);
 
     /**
-     * @notice Returns Premium Pool contract address.
-     * @return premiumPool_ The Premium Pool address.
-    */
-    function premiumPool() external view returns (address premiumPool_);
-
-    /**
-     * @notice Returns Premium Collector contract address.
-     * @return premiumCollector_ The Premium Collector address.
-    */
-    function premiumCollector() external view returns (address premiumCollector_);
-
-    /**
      * @notice Returns whether or not product is currently in paused state.
      * @return status True if product is paused.
     */
@@ -209,20 +184,7 @@ interface ISoteriaCoverageProduct {
      * @return amount The cover amount for given policy.
     */
     function coverLimitOf(uint256 policy_) external view returns (uint256 amount);
-
-    /**
-     * @notice The minimum amount of time a user must wait to withdraw funds.
-     * @return cooldownPeriod_ The cooldown period in seconds.
-     */
-    function cooldownPeriod() external view returns (uint256 cooldownPeriod_);
-
-    /**
-     * @notice The timestamp that a depositor's cooldown started.
-     * @param policyholder_ The policy holder
-     * @return cooldownStart_ The cooldown period start expressed as Unix timestamp
-     */
-    function cooldownStart(address policyholder_) external view returns (uint256 cooldownStart_);
-
+    
     /***************************************
     GOVERNANCE FUNCTIONS
     ***************************************/
@@ -235,29 +197,12 @@ interface ISoteriaCoverageProduct {
     function setRegistry(address registry_) external;
 
     /**
-     * @notice Sets the Premium Pool contract address.
-    */
-    function setPremiumPool(address premiumPool_) external;
-
-    /**
-     * @notice Sets the Premium Collector contract address.
-    */
-    function setPremiumCollector(address premiumCollector_) external;
-
-    /**
      * @notice Pauses or unpauses buying and extending policies.
      * Deactivating policies are unaffected by pause.
      * Can only be called by the current [**governor**](/docs/protocol/governance).
      * @param paused_ True to pause, false to unpause.
     */
     function setPaused(bool paused_) external;
-
-    /**
-     * @notice Sets the cooldown period that a user must wait after deactivating their policy, to withdraw funds from their Soteria account.
-     * Can only be called by the current [**governor**](/docs/protocol/governance).
-     * @param cooldownPeriod_ Cooldown period in seconds.
-     */
-    function setCooldownPeriod(uint256 cooldownPeriod_) external;
 
     /**
      * @notice set _maxRateNum.

--- a/contracts/interface/ISoteriaCoverageProduct.sol
+++ b/contracts/interface/ISoteriaCoverageProduct.sol
@@ -99,10 +99,12 @@ interface ISoteriaCoverageProduct {
     function withdraw(uint256 amount_) external;
 
     /**
-     * @notice Updates the cover amount of the policy.
+     * @notice Updates the cover amount of your policy
+     * @notice If you update the cover limit for your policy, you will exit the cooldown process if you already started it. This means that if you want to withdraw all your funds, you have to redo the 'deactivatePolicy() => withdraw()' process
      * @param newCoverLimit_ The new value to cover in **ETH**.
+     * @param referralCode_ Referral code
     */
-    function updateCoverLimit(uint256 newCoverLimit_) external;
+    function updateCoverLimit(uint256 newCoverLimit_, uint256 referralCode_) external;
 
     /**
      * @notice Deactivate a user's own policy.
@@ -239,6 +241,11 @@ interface ISoteriaCoverageProduct {
      */
     function cooldownStart(address policyholder_) external view returns (uint256 cooldownStart_);
 
+    /**
+     * @notice Gets the referral reward percentage in bps
+     * @return referralRewardPercentage_ The referral reward percentage
+     */
+    function referralRewardPercentage() external view returns (uint256 referralRewardPercentage_);
     /**
      * @notice Gets the unique referral code for a user.
      * @param user_ The user.

--- a/contracts/interface/ISoteriaCoverageProduct.sol
+++ b/contracts/interface/ISoteriaCoverageProduct.sol
@@ -25,6 +25,9 @@ interface ISoteriaCoverageProduct {
     /// @notice Emitted when Premium Collector address is updated.
     event PremiumCollectorSet(address premiumCollector);
 
+    /// @notice Emitted when Cover promotion admin address is updated.
+    event CoverPromotionAdminSet(address coverPromotionAdmin);
+
     /// @notice Emitted when pause is set.
     event PauseSet(bool pause);
 
@@ -64,6 +67,12 @@ interface ISoteriaCoverageProduct {
     /// @notice Emitted when reward points are set.
     event RewardPointsSet(address policyholder, uint256 amountGifted);
 
+    /// @notice Emitted when referralRewardPercentage is set.
+    event ReferralRewardPercentageSet(uint256 referralRewardPercentage);
+
+    /// @notice Emitted when referral rewards are earned;
+    event ReferralRewardsEarned(address rewardEarner, uint256 rewardPointsEarned);
+
     /***************************************
     POLICY FUNCTIONS
     ***************************************/
@@ -72,9 +81,10 @@ interface ISoteriaCoverageProduct {
      * @notice Activates policy on the behalf of the policyholder.
      * @param policyholder_ Holder of the position to cover.
      * @param coverLimit_ The value to cover in **ETH**.
+     * @param referralCode_ Referral code
      * @return policyID The ID of newly created policy.
     */
-    function activatePolicy(address policyholder_, uint256 coverLimit_) external payable returns (uint256 policyID);
+    function activatePolicy(address policyholder_, uint256 coverLimit_, uint256 referralCode_) external payable returns (uint256 policyID);
 
     /**
      * @notice Deposits funds for policy holders.
@@ -169,6 +179,12 @@ interface ISoteriaCoverageProduct {
     function premiumCollector() external view returns (address premiumCollector_);
 
     /**
+     * @notice Returns Cover promotion admin address
+     * @return coverPromotionAdmin_ The Cover promotion admin address.
+    */
+    function coverPromotionAdmin() external view returns (address coverPromotionAdmin_);
+
+    /**
      * @notice Returns whether or not product is currently in paused state.
      * @return status True if product is paused.
     */
@@ -223,6 +239,13 @@ interface ISoteriaCoverageProduct {
      */
     function cooldownStart(address policyholder_) external view returns (uint256 cooldownStart_);
 
+    /**
+     * @notice Gets the unique referral code for a user.
+     * @param user_ The user.
+     * @return referralCode_ The referral code.
+     */
+    function getReferralCode(address user_) external view returns (uint256 referralCode_);
+
     /***************************************
     GOVERNANCE FUNCTIONS
     ***************************************/
@@ -243,6 +266,11 @@ interface ISoteriaCoverageProduct {
      * @notice Sets the Premium Collector contract address.
     */
     function setPremiumCollector(address premiumCollector_) external;
+
+    /**
+     * @notice Sets the Cover promotion admin contract address.
+    */
+    function setCoverPromotionAdmin(address coverPromotionAdmin_) external;
 
     /**
      * @notice Pauses or unpauses buying and extending policies.
@@ -281,8 +309,19 @@ interface ISoteriaCoverageProduct {
     function setChargeCycle(uint256 chargeCycle_) external;
 
     /**
-     * @notice Enables governance to gift (and remove) 'free' cover to specific addresses.
+     * @notice set _referralRewardPercentage
      * Can only be called by the current [**governor**](/docs/protocol/governance).
+     * @param referralRewardPercentage_ Desired referralRewardPercentage.
+    */
+    function setReferralRewardPercentage(uint256 referralRewardPercentage_) external;
+
+    /***************************************
+    COVER PROMOTION ADMIN FUNCTIONS
+    ***************************************/
+
+    /**
+     * @notice Enables cover promotion admin to gift (and remove) 'free' cover to specific addresses.
+     * Can only be called by the current cover promotion admin.
      * @param policyholder_ The policy holder to set reward points for.
      * @param rewardPoints_ Desired amount of reward points.
     */

--- a/contracts/interface/ISoteriaCoverageProduct.sol
+++ b/contracts/interface/ISoteriaCoverageProduct.sol
@@ -19,8 +19,23 @@ interface ISoteriaCoverageProduct {
     /// @notice Emitted when Registry address is updated.
     event RegistrySet(address registry);
 
+    /// @notice Emitted when Premium Pool address is updated.
+    event PremiumPoolSet(address premiumPool);
+
+    /// @notice Emitted when Premium Collector address is updated.
+    event PremiumCollectorSet(address premiumCollector);
+
     /// @notice Emitted when pause is set.
     event PauseSet(bool pause);
+
+    /// @notice Emitted when a user enters cooldown mode.
+    event CooldownStarted(address policyholder, uint256 startTime);
+
+    /// @notice Emitted when a user leaves cooldown mode.
+    event CooldownStopped(address policyholder);
+
+    /// @notice Emitted when the cooldown period is set.
+    event CooldownPeriodSet(uint256 cooldownPeriod);
 
     /// @notice Emitted when a deposit is made.
     event DepositMade(address from, uint256 amount);
@@ -75,17 +90,15 @@ interface ISoteriaCoverageProduct {
 
     /**
      * @notice Updates the cover amount of the policy.
-     * @param policyID_ The policy ID to update.
      * @param newCoverLimit_ The new value to cover in **ETH**.
     */
-    function updateCoverLimit(uint256 policyID_, uint256 newCoverLimit_) external;
+    function updateCoverLimit(uint256 newCoverLimit_) external;
 
     /**
      * @notice Deactivate a user's own policy.
-     * @param policyID_ The policy ID to update.
      * User will receive their entire Soteria account balance.
      */
-     function deactivatePolicy(uint256 policyID_) external;
+     function deactivatePolicy() external;
 
     /***************************************
     VIEW FUNCTIONS
@@ -144,6 +157,18 @@ interface ISoteriaCoverageProduct {
     function riskManager() external view returns (address riskManager_);
 
     /**
+     * @notice Returns Premium Pool contract address.
+     * @return premiumPool_ The Premium Pool address.
+    */
+    function premiumPool() external view returns (address premiumPool_);
+
+    /**
+     * @notice Returns Premium Collector contract address.
+     * @return premiumCollector_ The Premium Collector address.
+    */
+    function premiumCollector() external view returns (address premiumCollector_);
+
+    /**
      * @notice Returns whether or not product is currently in paused state.
      * @return status True if product is paused.
     */
@@ -184,7 +209,20 @@ interface ISoteriaCoverageProduct {
      * @return amount The cover amount for given policy.
     */
     function coverLimitOf(uint256 policy_) external view returns (uint256 amount);
-    
+
+    /**
+     * @notice The minimum amount of time a user must wait to withdraw funds.
+     * @return cooldownPeriod_ The cooldown period in seconds.
+     */
+    function cooldownPeriod() external view returns (uint256 cooldownPeriod_);
+
+    /**
+     * @notice The timestamp that a depositor's cooldown started.
+     * @param policyholder_ The policy holder
+     * @return cooldownStart_ The cooldown period start expressed as Unix timestamp
+     */
+    function cooldownStart(address policyholder_) external view returns (uint256 cooldownStart_);
+
     /***************************************
     GOVERNANCE FUNCTIONS
     ***************************************/
@@ -197,12 +235,29 @@ interface ISoteriaCoverageProduct {
     function setRegistry(address registry_) external;
 
     /**
+     * @notice Sets the Premium Pool contract address.
+    */
+    function setPremiumPool(address premiumPool_) external;
+
+    /**
+     * @notice Sets the Premium Collector contract address.
+    */
+    function setPremiumCollector(address premiumCollector_) external;
+
+    /**
      * @notice Pauses or unpauses buying and extending policies.
      * Deactivating policies are unaffected by pause.
      * Can only be called by the current [**governor**](/docs/protocol/governance).
      * @param paused_ True to pause, false to unpause.
     */
     function setPaused(bool paused_) external;
+
+    /**
+     * @notice Sets the cooldown period that a user must wait after deactivating their policy, to withdraw funds from their Soteria account.
+     * Can only be called by the current [**governor**](/docs/protocol/governance).
+     * @param cooldownPeriod_ Cooldown period in seconds.
+     */
+    function setCooldownPeriod(uint256 cooldownPeriod_) external;
 
     /**
      * @notice set _maxRateNum.

--- a/contracts/products/SoteriaCoverageProduct.sol
+++ b/contracts/products/SoteriaCoverageProduct.sol
@@ -145,7 +145,7 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
         require(coverLimit_ > 0, "zero cover value");
         
         policyID = policyOf(policyholder_);
-        require(!policyStatus(policyID), "already bought policy");
+        require(!policyStatus(policyID), "policy already activated");
         require(_canPurchaseNewCover(0, coverLimit_), "insufficient capacity for new cover");
         require(msg.value + _accountBalanceOf[policyholder_] > ( _maxRateNum * _chargeCycle * coverLimit_ ) / _maxRateDenom, "insufficient deposit for minimum required account balance");
 
@@ -451,11 +451,8 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
         uint256 amountToPayTreasury = 0;
 
         for (uint256 i = 0; i < count; i++) {
-            // skip computation if policy inactive (coverLimit == 0)
-            if (coverLimitOf(policyOf(holders_[i])) == 0) {
-                continue;
-            }
-
+            // skip computation if policy inactive
+            if ( !policyStatus(_policyOf[holders_[i]]) ) continue;
             require(premiums_[i] <= ( _maxRateNum * _chargeCycle * coverLimitOf(policyOf(holders_[i])) ) / _maxRateDenom, "Charging more than promised maximum rate");
 
             // If policy holder can pay for premium charged in full
@@ -544,7 +541,7 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
      * @param soteriaActiveCoverLimit The active cover amount of soteria product.
     */
     function _updatePolicyManager(uint256 soteriaActiveCoverLimit) internal {
-        _policyManager.setSoteriaActiveCoverLimit(soteriaActiveCoverLimit);
+        _policyManager.setSoteriaActiveCoverAmount(soteriaActiveCoverLimit);
         emit PolicyManagerUpdated(soteriaActiveCoverLimit);
     }
 

--- a/contracts/products/SoteriaCoverageProduct.sol
+++ b/contracts/products/SoteriaCoverageProduct.sol
@@ -214,7 +214,9 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
       if (_accountBalanceOf[msg.sender] - amount_ > ( _maxRateNum * _chargeCycle * currentCoverLimit ) / _maxRateDenom) {
           _withdraw(msg.sender, amount_);
       } else {
-          deactivatePolicy(_policyOf[msg.sender]);
+          uint256 accountBalance = _accountBalanceOf[msg.sender];
+          _deactivatePolicy(msg.sender);
+          Address.sendValue(payable(msg.sender), accountBalance);
       }
     }
 

--- a/contracts/products/SoteriaCoverageProduct.sol
+++ b/contracts/products/SoteriaCoverageProduct.sol
@@ -38,6 +38,12 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
     /// @notice PolicyManager contract
     IPolicyManager internal _policyManager;
 
+    /// @notice Premium pool address to which charged premiums will be sent
+    address internal _premiumPool;
+
+    /// @notice Premium collector who has the exclusive privilege of calling chargePremiums() function
+    address internal _premiumCollector;
+
     /// @notice Cannot buy new policies while paused. (Default is False)
     bool internal _paused;
 
@@ -60,6 +66,21 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
 
     /// @notice Maximum epoch duration over which premiums are charged.
     uint256 internal _chargeCycle;
+
+    /**
+     * @notice The cooldown period
+     * Withdrawing total soteria account balance is a two-step process
+     * i.) Call deactivatePolicy(), which sets cover limit to 0 and begins a cooldown time
+     * ii.) After the cooldown period has been completed, the policy holder can then withdraw funds
+     * @dev We could use uint40 to store time, I thought it easier to just use uint256s in this contract. We're also not packing structs in this contract.
+     */
+    uint256 internal _cooldownPeriod;
+
+    /**
+     * @notice Policy holder address => Timestamp that a depositor's cooldown started
+     * @dev this is set to 0 to reset (default value is 0 in Solidity anyway)
+     */
+    mapping(address => uint256) internal _cooldownStart;
 
     /// @notice The policyholder => Soteria account balance.
     mapping(address => uint256) internal _accountBalanceOf; // Considered _soteriaAccountBalance name
@@ -149,6 +170,9 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
         require(_canPurchaseNewCover(0, coverLimit_), "insufficient capacity for new cover");
         require(msg.value + _accountBalanceOf[policyholder_] > _minRequiredAccountBalance(coverLimit_), "insufficient deposit for minimum required account balance");
 
+        // Exit cooldown
+        _exitCooldown(policyholder_);
+        
         // deposit funds
         _deposit(policyholder_, msg.value);
 
@@ -170,24 +194,23 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
     }
 
     /**
-     * @notice Updates the cover amount of the policy, either governance or policyholder can do this.
-     * @param policyID_ The policy ID to update.
+     * @notice Updates the cover amount of your policy
+     * @notice If you update the cover limit for your policy, you will exit the cooldown process if you already started it. This means that if you want to withdraw all your funds, you have to redo the 'deactivatePolicy() => withdraw()' process
      * @param newCoverLimit_ The new value to cover in **ETH**.
     */
-    function updateCoverLimit(uint256 policyID_, uint256 newCoverLimit_) external override nonReentrant whileUnpaused {
+    function updateCoverLimit(uint256 newCoverLimit_) external override nonReentrant whileUnpaused {
         require(newCoverLimit_ > 0, "zero cover value");
-        require(_exists(policyID_), "invalid policy");
-        address policyOwner = ownerOf(policyID_);
-        require(this.governance() == msg.sender || policyOwner == msg.sender, "not owner or governance");
-        uint256 currentCoverLimit = coverLimitOf(policyID_);
+        uint256 policyID = _policyOf[msg.sender];
+        require(_exists(policyID), "invalid policy");
+        uint256 currentCoverLimit = coverLimitOf(policyID);
         require(_canPurchaseNewCover(currentCoverLimit, newCoverLimit_), "insufficient capacity for new cover");
-        require(_accountBalanceOf[policyOwner] > _minRequiredAccountBalance(newCoverLimit_), "insufficient deposit for minimum required account balance");
+        require(_accountBalanceOf[msg.sender] > _minRequiredAccountBalance(newCoverLimit_), "insufficient deposit for minimum required account balance");
         
-        _coverLimitOf[policyID_] = newCoverLimit_;
-        uint256 newActiveCoverLimit = activeCoverLimit() + newCoverLimit_ - currentCoverLimit;
-        _activeCoverLimit = newActiveCoverLimit;
-        _updatePolicyManager(newActiveCoverLimit); // Need to change to _updateRiskManager(newActiveCoverLimit)
-        emit PolicyUpdated(policyID_);
+        _exitCooldown(msg.sender); // Reset cooldown
+        _coverLimitOf[policyID] = newCoverLimit_;
+        _activeCoverLimit = _activeCoverLimit + newCoverLimit_ - currentCoverLimit;
+        _updatePolicyManager(_activeCoverLimit); // Need to change to _updateRiskManager(newActiveCoverLimit)
+        emit PolicyUpdated(policyID);
     }
 
     /**
@@ -200,37 +223,32 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
 
     /**
      * @notice Withdraw ETH from Soteria account to user.
+     * @notice If cooldown has not passed, the user can only withdraw down to minRequiredAccountBalance
+     * @notice If cooldown has passed, the user can withdraw any amount
      * @param amount_ Amount policyholder desires to withdraw.
      * User Soteria account must have > minAccountBalance.
      * Otherwise account will be deactivated.
      */
     function withdraw(uint256 amount_) external override nonReentrant whileUnpaused {
-      require(amount_ <= _accountBalanceOf[msg.sender], "cannot withdraw this amount");
-      
+      require(amount_ <= _accountBalanceOf[msg.sender], "cannot withdraw > account balance");      
       uint256 currentCoverLimit = _coverLimitOf[_policyOf[msg.sender]];
 
-      if (_accountBalanceOf[msg.sender] - amount_ > _minRequiredAccountBalance(currentCoverLimit)) {
+      if ( _hasCooldownPassed(msg.sender) ) {
+          require(_accountBalanceOf[msg.sender] - amount_ > _minRequiredAccountBalance(currentCoverLimit), "must have > minRequiredAccountbalance");
           _withdraw(msg.sender, amount_);
       } else {
-          uint256 accountBalance = _accountBalanceOf[msg.sender];
-          _deactivatePolicy(msg.sender);
-          Address.sendValue(payable(msg.sender), accountBalance);
+          _withdraw(msg.sender, amount_);
       }
     }
 
     /**
-     * @notice Deactivate a user's own policy.
-     * @param policyID_ The policy ID to update.
-     * User will receive their entire Soteria account balance.
+     * @notice Deactivate a policy holder's own policy.
+     * Policy holder's cover will be set to 0, and cooldown timer will start
+     * Policy holder must wait out the cooldown, and then he/she will be able to withdraw their entire account balance
      */
-     function deactivatePolicy(uint256 policyID_) public override nonReentrant {
-        require(policyStatus(policyID_), "invalid policy");
-        address policyOwner = ownerOf(policyID_);
-        require(this.governance() == msg.sender || policyOwner == msg.sender, "not owner or governance");
-
-        uint256 refundAmount = accountBalanceOf(policyOwner);
-        _deactivatePolicy(policyOwner);
-        if (refundAmount > 0) Address.sendValue(payable(policyOwner), refundAmount);
+     function deactivatePolicy() public override nonReentrant {
+        require(policyStatus(_policyOf[msg.sender]), "invalid policy");
+        _deactivatePolicy(msg.sender);
     }
 
     /***************************************
@@ -306,6 +324,22 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
     }
 
     /**
+     * @notice Returns Premium Pool contract address.
+     * @return premiumPool_ The Premium Pool address.
+    */
+    function premiumPool() external view override returns (address premiumPool_) {
+        return _premiumPool;
+    }
+
+    /**
+     * @notice Returns Premium Collector contract address.
+     * @return premiumCollector_ The Premium Collector address.
+    */
+    function premiumCollector() external view override returns (address premiumCollector_) {
+        return _premiumCollector;
+    }
+
+    /**
      * @notice Returns whether or not product is currently in paused state.
      * @return status True if product is paused.
     */
@@ -362,6 +396,23 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
         return _coverLimitOf[policy_];
     }
 
+    /**
+     * @notice The minimum amount of time a user must wait to withdraw funds.
+     * @return cooldownPeriod_ The cooldown period in seconds.
+     */
+    function cooldownPeriod() external view override returns (uint256 cooldownPeriod_) {
+        return _cooldownPeriod;
+    }
+
+    /**
+     * @notice The timestamp that a depositor's cooldown started.
+     * @param policyholder_ The policy holder
+     * @return cooldownStart_ The cooldown period start expressed as Unix timestamp
+     */
+    function cooldownStart(address policyholder_) external view override returns (uint256 cooldownStart_) {
+        return _cooldownStart[policyholder_];
+    }
+
     /***************************************
     GOVERNANCE FUNCTIONS
     ***************************************/
@@ -382,6 +433,24 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
     }
 
     /**
+     * @notice Sets the Premium Pool contract address.
+    */
+    function setPremiumPool(address premiumPool_) external override onlyGovernance {
+        require(premiumPool_ != address(0x0), "zero address premium pool");
+        _premiumPool = premiumPool_;
+        emit PremiumPoolSet(premiumPool_);
+    }
+
+    /**
+     * @notice Sets the Premium Collector contract address.
+    */
+    function setPremiumCollector(address premiumCollector_) external override onlyGovernance {
+        require(premiumCollector_ != address(0x0), "zero address premium collector");
+        _premiumCollector = premiumCollector_;
+        emit PremiumCollectorSet(premiumCollector_);
+    }
+
+    /**
      * @notice Pauses or unpauses buying and extending policies.
      * Deactivating policies are unaffected by pause.
      * Can only be called by the current [**governor**](/docs/protocol/governance).
@@ -390,6 +459,16 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
     function setPaused(bool paused_) external override onlyGovernance {
         _paused = paused_;
         emit PauseSet(paused_);
+    }
+
+    /**
+     * @notice Sets the cooldown period that a user must wait after deactivating their policy, to withdraw funds from their Soteria account.
+     * Can only be called by the current [**governor**](/docs/protocol/governance).
+     * @param cooldownPeriod_ Cooldown period in seconds.
+     */
+    function setCooldownPeriod(uint256 cooldownPeriod_) external override onlyGovernance {
+        _cooldownPeriod = cooldownPeriod_;
+        emit CooldownPeriodSet(cooldownPeriod_);
     }
 
     /**
@@ -438,11 +517,12 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
      * @param holders_ The policy holders.
      * @param premiums_ The premium amounts in `wei` per policy holder.
     */
-    function chargePremiums(address[] calldata holders_, uint256[] calldata premiums_) external payable override onlyGovernance whileUnpaused {
+    function chargePremiums(address[] calldata holders_, uint256[] calldata premiums_) external payable override whileUnpaused {
         uint256 count = holders_.length;
+        require(msg.sender == _premiumCollector, "not premium collector");
         require(count == premiums_.length, "length mismatch");
         require(count <= policyCount(), "policy count exceeded");
-        uint256 amountToPayTreasury = 0;
+        uint256 amountToPayPremiumPool = 0;
 
         for (uint256 i = 0; i < count; i++) {
             // skip computation if policy inactive
@@ -457,7 +537,7 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
                     _rewardPointsOf[holders_[i]] -= premiums_[i];
                 } else {
                     uint256 amountDeductedFromSoteriaAccount = premiums_[i] - _rewardPointsOf[holders_[i]];
-                    amountToPayTreasury += amountDeductedFromSoteriaAccount;
+                    amountToPayPremiumPool += amountDeductedFromSoteriaAccount;
                     _accountBalanceOf[holders_[i]] -= amountDeductedFromSoteriaAccount;
                     _rewardPointsOf[holders_[i]] = 0;
                 }
@@ -465,14 +545,14 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
                 emit PremiumCharged(holders_[i], premiums_[i]);
             } else {
                 uint256 partialPremium = _accountBalanceOf[holders_[i]] + _rewardPointsOf[holders_[i]];
-                amountToPayTreasury += _accountBalanceOf[holders_[i]];
+                amountToPayPremiumPool += _accountBalanceOf[holders_[i]];
                 _rewardPointsOf[holders_[i]] = 0;
                 _deactivatePolicy(holders_[i]); // Difference between manually calling deactivatePolicy() and having _deactivatePolicy() called here, is that the remaining account balance goes to Treasury here instead of being returned to the user
                 emit PremiumPartiallyCharged(holders_[i], premiums_[i], partialPremium);
             }  
         }
-        // transfer premium to the treasury
-        ITreasury(payable(_registry.treasury())).routePremiums{value: amountToPayTreasury}();
+        // single transfer to the premium pool
+        Address.sendValue(payable(_premiumPool), amountToPayPremiumPool);
     }
 
     /***************************************
@@ -499,6 +579,8 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
      * @notice Adds funds to policy holder's balance.
      * @param policyholder The policy holder address.
      * @param amount The amount of fund to deposit.
+     * @dev Explicit decision that _deposit() will not affect, nor be affected by the cooldown mechanic. 
+     * Rationale: _deposit() doesn't affect cover limit, and cooldown mechanic is to protect protocol from manipulated cover limit
     */
     function _deposit(address policyholder, uint256 amount) internal whileUnpaused {
         _accountBalanceOf[policyholder] += amount;
@@ -521,6 +603,7 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
      * @param policyholder The address of the policy owner.
     */
     function _deactivatePolicy(address policyholder) internal {
+        _startCooldown(policyholder);
         uint256 policyID = _policyOf[policyholder];
         _activeCoverLimit -= _coverLimitOf[policyID];
         _coverLimitOf[policyID] = 0;
@@ -558,5 +641,32 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
         super._beforeTokenTransfer(from, to, tokenId);
         require(from == address(0), "only minting permitted");
         require(balanceOf(to) <= 1, "can only mint one SOPT");
+    }
+
+    /**
+     * @notice Starts the **cooldown** period for the user.
+     */
+    function _startCooldown(address policyholder) internal {
+        _cooldownStart[policyholder] = block.timestamp;
+        emit CooldownStarted(policyholder, _cooldownStart[policyholder]);
+    }
+
+    /**
+     * @notice Abandons the **cooldown** period for the user.
+     * @dev Original name for this function from the deprecated Vault.sol was stopCooldown()
+     * @dev Renamed this to _exitCooldown because "reset" gives the impression that you are starting the cooldown again, and "stop" gives the impression you are stopping the cooldown for it to pick up again later from where you stopped it
+     * @dev I thought "exit" gives the imagery that you are exitting the process, and you will need to restart it manually later (which is more accurate, if user calls updateCoverLimit(), they then need to redo 'deactivatePolicy() => withdraw()' to get their entire funds back)
+     */
+    function _exitCooldown(address policyholder) internal {
+        _cooldownStart[policyholder] = 0;
+        emit CooldownStopped(policyholder);
+    }
+
+    /**
+     * @notice Determine if cooldown has passed for a policy holder
+     * @return True if cooldown has passed, false if not
+     */
+    function _hasCooldownPassed(address policyholder) internal returns (bool) {
+        return block.timestamp >= _cooldownStart[policyholder] + _cooldownPeriod;
     }
 }

--- a/contracts/products/SoteriaCoverageProduct.sol
+++ b/contracts/products/SoteriaCoverageProduct.sol
@@ -7,6 +7,7 @@ import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "../Governable.sol";
 import "../interface/ITreasury.sol";
+import "../interface/IPolicyManager.sol";
 import "../interface/IRegistry.sol";
 import "../interface/IRiskManager.sol";
 import "../interface/IClaimsEscrow.sol";
@@ -26,6 +27,12 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
 
     /// @notice Registry contract.
     IRegistry internal _registry;
+
+    /// @notice Premium pool address to which charged premiums will be sent
+    address internal _premiumPool;
+
+    /// @notice Premium collector who has the exclusive privilege of calling chargePremiums() function
+    address internal _premiumCollector;
 
     /// @notice Cannot buy new policies while paused. (Default is False)
     bool internal _paused;
@@ -47,6 +54,21 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
     /// @notice Maximum epoch duration over which premiums are charged.
     uint256 internal _chargeCycle;
 
+    /**
+     * @notice The cooldown period
+     * Withdrawing total soteria account balance is a two-step process
+     * i.) Call deactivatePolicy(), which sets cover limit to 0 and begins a cooldown time
+     * ii.) After the cooldown period has been completed, the policy holder can then withdraw funds
+     * @dev We could use uint40 to store time, I thought it easier to just use uint256s in this contract. We're also not packing structs in this contract.
+     */
+    uint256 internal _cooldownPeriod;
+
+    /**
+     * @notice Policy holder address => Timestamp that a depositor's cooldown started
+     * @dev this is set to 0 to reset (default value is 0 in Solidity anyway)
+     */
+    mapping(address => uint256) internal _cooldownStart;
+
     /// @notice The policyholder => Soteria account balance.
     mapping(address => uint256) internal _accountBalanceOf; // Considered _soteriaAccountBalance name
 
@@ -55,6 +77,10 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
 
     /// @notice The cover limit for each policy(policyID => coverLimit).
     mapping (uint256 => uint256) internal _coverLimitOf;
+
+    /// @notice This mapping is created for the purpose of avoiding the unintended side effect where `user deactivates policy -> cover limit set to 0 -> minRequiredAccountBalance also set to 0 unintentionally because minRequiredAccountBalance = coverLimit * chargeCycle * maxRate -> user can withdraw all funds immediately after deactivating account
+    /// @dev This mapping is intended to mirror the _coverLimitOf mapping, except time between cooldown start and after cooldown completed
+    mapping (uint256 => uint256) internal _preDeactivateCoverLimitOf;
 
     /// @notice The policy holder => reward points. Having a reward points mechanism enables `free` cover gifts and discounts for referrals.
     mapping (address => uint256) internal _rewardPointsOf;
@@ -106,7 +132,7 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
     }
 
     /***************************************
-    POLICY FUNCTIONS
+    POLICY HOLDER FUNCTIONS
     ***************************************/
 
     /**
@@ -124,6 +150,9 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
         require(_canPurchaseNewCover(0, coverLimit_), "insufficient capacity for new cover");
         require(msg.value + _accountBalanceOf[policyholder_] > _minRequiredAccountBalance(coverLimit_), "insufficient deposit for minimum required account balance");
 
+        // Exit cooldown
+        _exitCooldown(policyholder_);
+        
         // deposit funds
         _deposit(policyholder_, msg.value);
 
@@ -133,31 +162,33 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
             _policyOf[policyholder_] = policyID;
             _mint(policyholder_, policyID);
         }
-        
-        _coverLimitOf[policyID] = coverLimit_;
-        // update policy manager active cover amount
+
+        // update cover amount
         _updateActiveCoverLimit(0, coverLimit_);
+        _coverLimitOf[policyID] = coverLimit_;
+        _preDeactivateCoverLimitOf[policyID] = coverLimit_;
         emit PolicyCreated(policyID);
         return policyID;
     }
 
     /**
-     * @notice Updates the cover amount of the policy, either governance or policyholder can do this.
-     * @param policyID_ The policy ID to update.
+     * @notice Updates the cover amount of your policy
+     * @notice If you update the cover limit for your policy, you will exit the cooldown process if you already started it. This means that if you want to withdraw all your funds, you have to redo the 'deactivatePolicy() => withdraw()' process
      * @param newCoverLimit_ The new value to cover in **ETH**.
     */
-    function updateCoverLimit(uint256 policyID_, uint256 newCoverLimit_) external override nonReentrant whileUnpaused {
+    function updateCoverLimit(uint256 newCoverLimit_) external override nonReentrant whileUnpaused {
         require(newCoverLimit_ > 0, "zero cover value");
-        require(_exists(policyID_), "invalid policy");
-        address policyOwner = ownerOf(policyID_);
-        require(this.governance() == msg.sender || policyOwner == msg.sender, "not owner or governance");
-        uint256 currentCoverLimit = coverLimitOf(policyID_);
+        uint256 policyID = _policyOf[msg.sender];
+        require(_exists(policyID), "invalid policy");
+        uint256 currentCoverLimit = coverLimitOf(policyID);
         require(_canPurchaseNewCover(currentCoverLimit, newCoverLimit_), "insufficient capacity for new cover");
-        require(_accountBalanceOf[policyOwner] > _minRequiredAccountBalance(newCoverLimit_), "insufficient deposit for minimum required account balance");
+        require(_accountBalanceOf[msg.sender] > _minRequiredAccountBalance(newCoverLimit_), "insufficient deposit for minimum required account balance");
         
-        _coverLimitOf[policyID_] = newCoverLimit_;
-        _updateActiveCoverLimit(currentCoverLimit, newCoverLimit_); // Need to change to _updateRiskManager(newActiveCoverLimit)
-        emit PolicyUpdated(policyID_);
+        _exitCooldown(msg.sender); // Reset cooldown
+        _coverLimitOf[policyID] = newCoverLimit_;
+        _preDeactivateCoverLimitOf[policyID] = newCoverLimit_;
+        _updateActiveCoverLimit(currentCoverLimit, newCoverLimit_);
+        emit PolicyUpdated(policyID);
     }
 
     /**
@@ -170,37 +201,32 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
 
     /**
      * @notice Withdraw ETH from Soteria account to user.
+     * @notice If cooldown has passed, the user can withdraw any amount
+     * @notice If cooldown has not passed, the user can only withdraw down to minRequiredAccountBalance
      * @param amount_ Amount policyholder desires to withdraw.
      * User Soteria account must have > minAccountBalance.
      * Otherwise account will be deactivated.
      */
     function withdraw(uint256 amount_) external override nonReentrant whileUnpaused {
-      require(amount_ <= _accountBalanceOf[msg.sender], "cannot withdraw this amount");
-      
-      uint256 currentCoverLimit = _coverLimitOf[_policyOf[msg.sender]];
+      require(amount_ <= _accountBalanceOf[msg.sender], "cannot withdraw > account balance");      
+      uint256 preDeactivateCoverLimit = _preDeactivateCoverLimitOf[_policyOf[msg.sender]];
 
-      if (_accountBalanceOf[msg.sender] - amount_ > _minRequiredAccountBalance(currentCoverLimit)) {
-          _withdraw(msg.sender, amount_);
+      if ( _hasCooldownPassed(msg.sender) ) {
+        _withdraw(msg.sender, amount_);
       } else {
-          uint256 accountBalance = _accountBalanceOf[msg.sender];
-          _deactivatePolicy(msg.sender);
-          Address.sendValue(payable(msg.sender), accountBalance);
+        require(_accountBalanceOf[msg.sender] - amount_ > _minRequiredAccountBalance(preDeactivateCoverLimit), "must have > minRequiredAccountbalance");
+        _withdraw(msg.sender, amount_);
       }
     }
 
     /**
-     * @notice Deactivate a user's own policy.
-     * @param policyID_ The policy ID to update.
-     * User will receive their entire Soteria account balance.
+     * @notice Deactivate a policy holder's own policy.
+     * Policy holder's cover will be set to 0, and cooldown timer will start
+     * Policy holder must wait out the cooldown, and then he/she will be able to withdraw their entire account balance
      */
-     function deactivatePolicy(uint256 policyID_) public override nonReentrant {
-        require(policyStatus(policyID_), "invalid policy");
-        address policyOwner = ownerOf(policyID_);
-        require(this.governance() == msg.sender || policyOwner == msg.sender, "not owner or governance");
-
-        uint256 refundAmount = accountBalanceOf(policyOwner);
-        _deactivatePolicy(policyOwner);
-        if (refundAmount > 0) Address.sendValue(payable(policyOwner), refundAmount);
+     function deactivatePolicy() public override nonReentrant {
+        require(policyStatus(_policyOf[msg.sender]), "invalid policy");
+        _deactivatePolicy(msg.sender);
     }
 
     /***************************************
@@ -276,6 +302,22 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
     }
 
     /**
+     * @notice Returns Premium Pool contract address.
+     * @return premiumPool_ The Premium Pool address.
+    */
+    function premiumPool() external view override returns (address premiumPool_) {
+        return _premiumPool;
+    }
+
+    /**
+     * @notice Returns Premium Collector contract address.
+     * @return premiumCollector_ The Premium Collector address.
+    */
+    function premiumCollector() external view override returns (address premiumCollector_) {
+        return _premiumCollector;
+    }
+
+    /**
      * @notice Returns whether or not product is currently in paused state.
      * @return status True if product is paused.
     */
@@ -332,6 +374,23 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
         return _coverLimitOf[policy_];
     }
 
+    /**
+     * @notice The minimum amount of time a user must wait to withdraw funds.
+     * @return cooldownPeriod_ The cooldown period in seconds.
+     */
+    function cooldownPeriod() external view override returns (uint256 cooldownPeriod_) {
+        return _cooldownPeriod;
+    }
+
+    /**
+     * @notice The timestamp that a depositor's cooldown started.
+     * @param policyholder_ The policy holder
+     * @return cooldownStart_ The cooldown period start expressed as Unix timestamp
+     */
+    function cooldownStart(address policyholder_) external view override returns (uint256 cooldownStart_) {
+        return _cooldownStart[policyholder_];
+    }
+
     /***************************************
     GOVERNANCE FUNCTIONS
     ***************************************/
@@ -349,6 +408,24 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
     }
 
     /**
+     * @notice Sets the Premium Pool contract address.
+    */
+    function setPremiumPool(address premiumPool_) external override onlyGovernance {
+        require(premiumPool_ != address(0x0), "zero address premium pool");
+        _premiumPool = premiumPool_;
+        emit PremiumPoolSet(premiumPool_);
+    }
+
+    /**
+     * @notice Sets the Premium Collector contract address.
+    */
+    function setPremiumCollector(address premiumCollector_) external override onlyGovernance {
+        require(premiumCollector_ != address(0x0), "zero address premium collector");
+        _premiumCollector = premiumCollector_;
+        emit PremiumCollectorSet(premiumCollector_);
+    }
+
+    /**
      * @notice Pauses or unpauses buying and extending policies.
      * Deactivating policies are unaffected by pause.
      * Can only be called by the current [**governor**](/docs/protocol/governance).
@@ -357,6 +434,16 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
     function setPaused(bool paused_) external override onlyGovernance {
         _paused = paused_;
         emit PauseSet(paused_);
+    }
+
+    /**
+     * @notice Sets the cooldown period that a user must wait after deactivating their policy, to withdraw funds from their Soteria account.
+     * Can only be called by the current [**governor**](/docs/protocol/governance).
+     * @param cooldownPeriod_ Cooldown period in seconds.
+     */
+    function setCooldownPeriod(uint256 cooldownPeriod_) external override onlyGovernance {
+        _cooldownPeriod = cooldownPeriod_;
+        emit CooldownPeriodSet(cooldownPeriod_);
     }
 
     /**
@@ -400,16 +487,21 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
         emit RewardPointsSet(policyholder_, rewardPoints_);
     }  
 
+    /***************************************
+    PREMIUM COLLECTOR FUNCTIONS
+    ***************************************/
+
     /**
      * @notice Charge premiums for each policy holder.
      * @param holders_ The policy holders.
      * @param premiums_ The premium amounts in `wei` per policy holder.
     */
-    function chargePremiums(address[] calldata holders_, uint256[] calldata premiums_) external payable override onlyGovernance whileUnpaused {
+    function chargePremiums(address[] calldata holders_, uint256[] calldata premiums_) external payable override whileUnpaused {
         uint256 count = holders_.length;
+        require(msg.sender == _premiumCollector, "not premium collector");
         require(count == premiums_.length, "length mismatch");
         require(count <= policyCount(), "policy count exceeded");
-        uint256 amountToPayTreasury = 0;
+        uint256 amountToPayPremiumPool = 0;
 
         for (uint256 i = 0; i < count; i++) {
             // skip computation if policy inactive
@@ -424,7 +516,7 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
                     _rewardPointsOf[holders_[i]] -= premiums_[i];
                 } else {
                     uint256 amountDeductedFromSoteriaAccount = premiums_[i] - _rewardPointsOf[holders_[i]];
-                    amountToPayTreasury += amountDeductedFromSoteriaAccount;
+                    amountToPayPremiumPool += amountDeductedFromSoteriaAccount;
                     _accountBalanceOf[holders_[i]] -= amountDeductedFromSoteriaAccount;
                     _rewardPointsOf[holders_[i]] = 0;
                 }
@@ -432,14 +524,15 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
                 emit PremiumCharged(holders_[i], premiums_[i]);
             } else {
                 uint256 partialPremium = _accountBalanceOf[holders_[i]] + _rewardPointsOf[holders_[i]];
-                amountToPayTreasury += _accountBalanceOf[holders_[i]];
+                amountToPayPremiumPool += _accountBalanceOf[holders_[i]];
+                _accountBalanceOf[holders_[i]] = 0;
                 _rewardPointsOf[holders_[i]] = 0;
-                _deactivatePolicy(holders_[i]); // Difference between manually calling deactivatePolicy() and having _deactivatePolicy() called here, is that the remaining account balance goes to Treasury here instead of being returned to the user
+                _deactivatePolicy(holders_[i]);
                 emit PremiumPartiallyCharged(holders_[i], premiums_[i], partialPremium);
             }  
         }
-        // transfer premium to the treasury
-        ITreasury(payable(_registry.treasury())).routePremiums{value: amountToPayTreasury}();
+        // single transfer to the premium pool
+        Address.sendValue(payable(_premiumPool), amountToPayPremiumPool);
     }
 
     /***************************************
@@ -453,19 +546,17 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
     * @return acceptable True there is sufficient capacity for requested new coverage amount, false otherwise.
     */
     function _canPurchaseNewCover(uint256 existingTotalCover_, uint256 newTotalCover_) internal view returns (bool acceptable) {
-        // Redundant check if _activeCoverLimit will be lowered
-        if (newTotalCover_ < existingTotalCover_) return true;
-        else {
-            uint256 changeInTotalCover = newTotalCover_ - existingTotalCover_;
-            if (changeInTotalCover < availableCoverCapacity()) return true;
-            else return false;
-        }
+        uint256 changeInTotalCover = newTotalCover_ - existingTotalCover_;
+        if (changeInTotalCover < availableCoverCapacity()) return true;
+        else return false;
     }
 
     /**
      * @notice Adds funds to policy holder's balance.
      * @param policyholder The policy holder address.
      * @param amount The amount of fund to deposit.
+     * @dev Explicit decision that _deposit() will not affect, nor be affected by the cooldown mechanic. 
+     * Rationale: _deposit() doesn't affect cover limit, and cooldown mechanic is to protect protocol from manipulated cover limit
     */
     function _deposit(address policyholder, uint256 amount) internal whileUnpaused {
         _accountBalanceOf[policyholder] += amount;
@@ -488,11 +579,10 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
      * @param policyholder The address of the policy owner.
     */
     function _deactivatePolicy(address policyholder) internal {
+        _startCooldown(policyholder);
         uint256 policyID = _policyOf[policyholder];
-        // update active cover limit
         _updateActiveCoverLimit(_coverLimitOf[policyID], 0);
         _coverLimitOf[policyID] = 0;
-        _accountBalanceOf[policyholder] = 0;
         emit PolicyDeactivated(policyID);
     }
 
@@ -509,7 +599,7 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
      * @notice Calculate minimum required account balance for a given cover limit
      * @param coverLimit cover limit.
     */
-    function _minRequiredAccountBalance(uint256 coverLimit) internal view returns (uint256 minRequiredAccountBalance) {
+    function _minRequiredAccountBalance(uint256 coverLimit) internal returns (uint256 minRequiredAccountBalance) {
         minRequiredAccountBalance = ( _maxRateNum * _chargeCycle * coverLimit ) / _maxRateDenom;
     }
 
@@ -524,5 +614,33 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
         super._beforeTokenTransfer(from, to, tokenId);
         require(from == address(0), "only minting permitted");
         require(balanceOf(to) <= 1, "can only mint one SOPT");
+    }
+
+    /**
+     * @notice Starts the **cooldown** period for the user.
+     */
+    function _startCooldown(address policyholder) internal {
+        _cooldownStart[policyholder] = block.timestamp;
+        emit CooldownStarted(policyholder, _cooldownStart[policyholder]);
+    }
+
+    /**
+     * @notice Abandons the **cooldown** period for the user.
+     * @dev Original name for this function from the deprecated Vault.sol was stopCooldown()
+     * @dev Renamed this to _exitCooldown because "reset" gives the impression that you are starting the cooldown again, and "stop" gives the impression you are stopping the cooldown for it to pick up again later from where you stopped it
+     * @dev I thought "exit" gives the imagery that you are exitting the process, and you will need to restart it manually later (which is more accurate, if user calls updateCoverLimit(), they then need to redo 'deactivatePolicy() => withdraw()' to get their entire funds back)
+     */
+    function _exitCooldown(address policyholder) internal {
+        _cooldownStart[policyholder] = 0;
+        emit CooldownStopped(policyholder);
+    }
+
+    /**
+     * @notice Determine if cooldown has passed for a policy holder
+     * @return True if cooldown has passed, false if not
+     */
+    function _hasCooldownPassed(address policyholder) internal returns (bool) {
+        if (_cooldownStart[policyholder] == 0) {return false;}
+        else {return block.timestamp >= _cooldownStart[policyholder] + _cooldownPeriod;}
     }
 }

--- a/contracts/products/SoteriaCoverageProduct.sol
+++ b/contracts/products/SoteriaCoverageProduct.sol
@@ -7,7 +7,6 @@ import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "../Governable.sol";
 import "../interface/ITreasury.sol";
-import "../interface/IPolicyManager.sol";
 import "../interface/IRegistry.sol";
 import "../interface/IRiskManager.sol";
 import "../interface/IClaimsEscrow.sol";
@@ -25,18 +24,8 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
     GLOBAL VARIABLES
     ***************************************/
 
-    /// @notice Typehash for claim submissions.
-    // solhint-disable-next-line var-name-mixedcase
-    bytes32 internal immutable _SUBMIT_CLAIM_TYPEHASH;
-
     /// @notice Registry contract.
     IRegistry internal _registry;
-
-    /// @notice RiskManager contract
-    IRiskManager internal _riskManager;
-
-    /// @notice PolicyManager contract
-    IPolicyManager internal _policyManager;
 
     /// @notice Cannot buy new policies while paused. (Default is False)
     bool internal _paused;
@@ -44,9 +33,6 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
     /***************************************
     BOOK-KEEPING VARIABLES
     ***************************************/
-
-    /// @notice The current amount covered (in wei).
-    uint256 internal _activeCoverLimit;
 
     /// @notice The total policy count.
     uint256 internal _totalPolicyCount;
@@ -86,29 +72,18 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
      * @notice Constructs `Soteria` product.
      * @param governance_ The governor.
      * @param registry_ The [`Registry`](./Registry) contract address.
-     * @param typehash_ The typehash for submitting claims.
      * @param domain_ The user readable name of the EIP712 signing domain.
      * @param version_ The current major version of the signing domain.
      */
     constructor(
         address governance_,
         address registry_,
-        bytes32 typehash_,
         string memory domain_,
         string memory version_
     ) ERC721("Soteria Policy", "SOPT") Governable(governance_) EIP712(domain_, version_) {
-        // set registry
         require(registry_ != address(0x0), "zero address registry");
         _registry = IRegistry(registry_);
-
-        // set riskmanager
         require(_registry.riskManager() != address(0x0), "zero address riskmanager");
-        _riskManager = IRiskManager(_registry.riskManager());
-
-        // set policymanager
-        require(_registry.policyManager() != address(0x0), "zero address policymanager");
-        _policyManager = IPolicyManager(_registry.policyManager());
-        _SUBMIT_CLAIM_TYPEHASH = typehash_;
     }
     
     /***************************************
@@ -158,13 +133,10 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
             _policyOf[policyholder_] = policyID;
             _mint(policyholder_, policyID);
         }
-
-        // update cover amount
-        _activeCoverLimit += coverLimit_;
+        
         _coverLimitOf[policyID] = coverLimit_;
-       
         // update policy manager active cover amount
-        _updatePolicyManager(_activeCoverLimit); // Need to change to _updateRiskManager(_activeCoverLimit)
+        _updateActiveCoverLimit(0, coverLimit_);
         emit PolicyCreated(policyID);
         return policyID;
     }
@@ -184,9 +156,7 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
         require(_accountBalanceOf[policyOwner] > _minRequiredAccountBalance(newCoverLimit_), "insufficient deposit for minimum required account balance");
         
         _coverLimitOf[policyID_] = newCoverLimit_;
-        uint256 newActiveCoverLimit = activeCoverLimit() + newCoverLimit_ - currentCoverLimit;
-        _activeCoverLimit = newActiveCoverLimit;
-        _updatePolicyManager(newActiveCoverLimit); // Need to change to _updateRiskManager(newActiveCoverLimit)
+        _updateActiveCoverLimit(currentCoverLimit, newCoverLimit_); // Need to change to _updateRiskManager(newActiveCoverLimit)
         emit PolicyUpdated(policyID_);
     }
 
@@ -286,7 +256,7 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
      * @return cover The max amount of cover in `wei`
     */
     function maxCover() public view override returns (uint256 cover) {
-        return _riskManager.maxCoverPerStrategy(address(this));
+        return IRiskManager(_registry.riskManager()).maxCoverPerStrategy(address(this));
     }
 
     /**
@@ -302,7 +272,7 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
      * @return riskManager_ The `RiskManager` address.
     */
     function riskManager() external view override returns (address riskManager_) {
-        return address(_riskManager);
+        return address(_registry.riskManager());
     }
 
     /**
@@ -318,7 +288,7 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
      * @return amount The active cover limit.
     */
     function activeCoverLimit() public view override returns (uint256 amount) {
-        return _activeCoverLimit;
+        return IRiskManager(_registry.riskManager()).activeCoverLimitPerStrategy(address(this));
     }
 
     /**
@@ -375,9 +345,6 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
         require(registry_ != address(0x0), "zero address registry");
         _registry = IRegistry(registry_);
         require(_registry.riskManager() != address(0x0), "zero address riskmanager");
-        _riskManager = IRiskManager(_registry.riskManager());
-        require(_registry.policyManager() != address(0x0), "zero address policymanager");
-        _policyManager = IPolicyManager(_registry.policyManager());
         emit RegistrySet(registry_);
     }
 
@@ -522,28 +489,27 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
     */
     function _deactivatePolicy(address policyholder) internal {
         uint256 policyID = _policyOf[policyholder];
-        _activeCoverLimit -= _coverLimitOf[policyID];
+        // update active cover limit
+        _updateActiveCoverLimit(_coverLimitOf[policyID], 0);
         _coverLimitOf[policyID] = 0;
         _accountBalanceOf[policyholder] = 0;
-        _updatePolicyManager(_activeCoverLimit); // Need to change to _updateRiskManager(_activeCoverLimit)
         emit PolicyDeactivated(policyID);
     }
 
-    // REQUIRE CHANGING PolicyManager.sol & RiskManager.sol so that RiskManager tracks the activeCoverLimit
     /**
-     * @notice Updates policy manager's active cover amount.
-     * @param soteriaActiveCoverLimit The active cover amount of soteria product.
+     * @notice Updates active cover limit of `Soteria`.
+     * @param currentCoverLimit The current cover limit of the policy.
+     * @param newCoverLimit The new cover limit of the policy.
     */
-    function _updatePolicyManager(uint256 soteriaActiveCoverLimit) internal {
-        _policyManager.setSoteriaActiveCoverAmount(soteriaActiveCoverLimit);
-        emit PolicyManagerUpdated(soteriaActiveCoverLimit);
+    function _updateActiveCoverLimit(uint256 currentCoverLimit, uint256 newCoverLimit) internal {
+        IRiskManager(_registry.riskManager()).updateActiveCoverLimitForStrategy(address(this), currentCoverLimit, newCoverLimit);
     }
 
     /**
      * @notice Calculate minimum required account balance for a given cover limit
      * @param coverLimit cover limit.
     */
-    function _minRequiredAccountBalance(uint256 coverLimit) internal returns (uint256 minRequiredAccountBalance) {
+    function _minRequiredAccountBalance(uint256 coverLimit) internal view returns (uint256 minRequiredAccountBalance) {
         minRequiredAccountBalance = ( _maxRateNum * _chargeCycle * coverLimit ) / _maxRateDenom;
     }
 

--- a/contracts/products/SoteriaCoverageProduct.sol
+++ b/contracts/products/SoteriaCoverageProduct.sol
@@ -147,7 +147,7 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
         policyID = policyOf(policyholder_);
         require(!policyStatus(policyID), "already bought policy");
         require(_canPurchaseNewCover(0, coverLimit_), "insufficient capacity for new cover");
-        require(msg.value > ( _maxRateNum * _chargeCycle * coverLimit_ ) / _maxRateDenom, "insufficient deposit for minimum required account balance");
+        require(msg.value + _accountBalanceOf[policyholder_] > ( _maxRateNum * _chargeCycle * coverLimit_ ) / _maxRateDenom, "insufficient deposit for minimum required account balance");
 
         // deposit funds
         _deposit(policyholder_, msg.value);
@@ -179,11 +179,12 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
         require(_exists(policyID_), "invalid policy");
         // These following 2 require's are awkward, we would ideally like a modifier or single require statement to evaluate `msg.sender == ownerOf(policyID_) || onlyGovernance modifier`
         // Require `this.` syntax to access external functions of inherited Governance.sol
+        address policyOwner = ownerOf(policyID_);
         require(!this.governanceIsLocked(), "permanently locked by governance");
-        require(this.governance() == msg.sender || ownerOf(policyID_) == msg.sender, "Not owner or governance");
+        require(this.governance() == msg.sender || policyOwner == msg.sender, "Not owner or governance");
         uint256 currentCoverLimit = coverLimitOf(policyID_);
         require(_canPurchaseNewCover(currentCoverLimit, newCoverLimit_), "insufficient capacity for new cover");
-        require(_accountBalanceOf[msg.sender] > ( _maxRateNum * _chargeCycle * newCoverLimit_ ) / _maxRateDenom, "insufficient deposit for minimum required account balance");
+        require(_accountBalanceOf[policyOwner] > ( _maxRateNum * _chargeCycle * newCoverLimit_ ) / _maxRateDenom, "insufficient deposit for minimum required account balance");
         
         _coverLimitOf[policyID_] = newCoverLimit_;
         uint256 newActiveCoverLimit = activeCoverLimit() + newCoverLimit_ - currentCoverLimit;

--- a/contracts/products/SoteriaCoverageProduct.sol
+++ b/contracts/products/SoteriaCoverageProduct.sol
@@ -147,7 +147,7 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
         policyID = policyOf(policyholder_);
         require(!policyStatus(policyID), "policy already activated");
         require(_canPurchaseNewCover(0, coverLimit_), "insufficient capacity for new cover");
-        require(msg.value + _accountBalanceOf[policyholder_] > ( _maxRateNum * _chargeCycle * coverLimit_ ) / _maxRateDenom, "insufficient deposit for minimum required account balance");
+        require(msg.value + _accountBalanceOf[policyholder_] > _minRequiredAccountBalance(coverLimit_), "insufficient deposit for minimum required account balance");
 
         // deposit funds
         _deposit(policyholder_, msg.value);
@@ -178,10 +178,10 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
         require(newCoverLimit_ > 0, "zero cover value");
         require(_exists(policyID_), "invalid policy");
         address policyOwner = ownerOf(policyID_);
-        require(this.governance() == msg.sender || policyOwner == msg.sender, "Not owner or governance");
+        require(this.governance() == msg.sender || policyOwner == msg.sender, "not owner or governance");
         uint256 currentCoverLimit = coverLimitOf(policyID_);
         require(_canPurchaseNewCover(currentCoverLimit, newCoverLimit_), "insufficient capacity for new cover");
-        require(_accountBalanceOf[policyOwner] > ( _maxRateNum * _chargeCycle * newCoverLimit_ ) / _maxRateDenom, "insufficient deposit for minimum required account balance");
+        require(_accountBalanceOf[policyOwner] > _minRequiredAccountBalance(newCoverLimit_), "insufficient deposit for minimum required account balance");
         
         _coverLimitOf[policyID_] = newCoverLimit_;
         uint256 newActiveCoverLimit = activeCoverLimit() + newCoverLimit_ - currentCoverLimit;
@@ -209,7 +209,7 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
       
       uint256 currentCoverLimit = _coverLimitOf[_policyOf[msg.sender]];
 
-      if (_accountBalanceOf[msg.sender] - amount_ > ( _maxRateNum * _chargeCycle * currentCoverLimit ) / _maxRateDenom) {
+      if (_accountBalanceOf[msg.sender] - amount_ > _minRequiredAccountBalance(currentCoverLimit)) {
           _withdraw(msg.sender, amount_);
       } else {
           uint256 accountBalance = _accountBalanceOf[msg.sender];
@@ -226,7 +226,7 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
      function deactivatePolicy(uint256 policyID_) public override nonReentrant {
         require(policyStatus(policyID_), "invalid policy");
         address policyOwner = ownerOf(policyID_);
-        require(this.governance() == msg.sender || policyOwner == msg.sender, "Not owner or governance");
+        require(this.governance() == msg.sender || policyOwner == msg.sender, "not owner or governance");
 
         uint256 refundAmount = accountBalanceOf(policyOwner);
         _deactivatePolicy(policyOwner);
@@ -447,7 +447,7 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
         for (uint256 i = 0; i < count; i++) {
             // skip computation if policy inactive
             if ( !policyStatus(_policyOf[holders_[i]]) ) continue;
-            require(premiums_[i] <= ( _maxRateNum * _chargeCycle * coverLimitOf(policyOf(holders_[i])) ) / _maxRateDenom, "Charging more than promised maximum rate");
+            require(premiums_[i] <= _minRequiredAccountBalance(coverLimitOf(policyOf(holders_[i]))), "charging more than promised maximum rate");
 
             // If policy holder can pay for premium charged in full
             if (_accountBalanceOf[holders_[i]] + _rewardPointsOf[holders_[i]] >= premiums_[i]) {
@@ -537,6 +537,14 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
     function _updatePolicyManager(uint256 soteriaActiveCoverLimit) internal {
         _policyManager.setSoteriaActiveCoverAmount(soteriaActiveCoverLimit);
         emit PolicyManagerUpdated(soteriaActiveCoverLimit);
+    }
+
+    /**
+     * @notice Calculate minimum required account balance for a given cover limit
+     * @param coverLimit cover limit.
+    */
+    function _minRequiredAccountBalance(uint256 coverLimit) internal returns (uint256 minRequiredAccountBalance) {
+        minRequiredAccountBalance = ( _maxRateNum * _chargeCycle * coverLimit ) / _maxRateDenom;
     }
 
     /**

--- a/contracts/products/SoteriaCoverageProduct.sol
+++ b/contracts/products/SoteriaCoverageProduct.sol
@@ -682,7 +682,6 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
     function _beforeTokenTransfer(address from, address to, uint256 tokenId) internal virtual override {
         super._beforeTokenTransfer(from, to, tokenId);
         require(from == address(0), "only minting permitted");
-        require(balanceOf(to) <= 1, "can only mint one SOPT");
     }
 
     /**
@@ -730,7 +729,7 @@ contract SoteriaCoverageProduct is ISoteriaCoverageProduct, ERC721, EIP712, Reen
      */
     function _processReferralCode(address policyholder_, uint256 coverLimit_, uint256 referralCode_) internal {
         address referrer = address(uint160(referralCode_));
-        require(referrer != address(0), "cannot have zero address referrer");
+        // require(referrer != address(0), "cannot have zero address referrer"); // Redundant because we cannot call _processReferralCode with referralCode_ = 0
         require(referrer != policyholder_, "cannot refer to self");
         require (!_isReferralCodeUsed[_policyOf[policyholder_]], "cannot use referral code again");
         

--- a/test/ClaimsEscrow.test.ts
+++ b/test/ClaimsEscrow.test.ts
@@ -50,7 +50,7 @@ describe("ClaimsEscrow", function () {
     await registry.connect(governor).setVault(vault.address);
     claimsEscrow = (await deployContract(deployer, artifacts.ClaimsEscrow, [governor.address, registry.address])) as ClaimsEscrow;
     await registry.connect(governor).setClaimsEscrow(claimsEscrow.address);
-    policyManager = (await deployContract(deployer, artifacts.PolicyManager, [governor.address])) as PolicyManager;
+    policyManager = (await deployContract(deployer, artifacts.PolicyManager, [governor.address, registry.address])) as PolicyManager;
     await registry.connect(governor).setPolicyManager(policyManager.address);
 
     await policyManager.connect(governor).addProduct(mockProduct.address);

--- a/test/CoverageProduct.test.ts
+++ b/test/CoverageProduct.test.ts
@@ -69,7 +69,7 @@ describe("CoverageProduct", function () {
     await registry.connect(governor).setClaimsEscrow(claimsEscrow.address);
     treasury = (await deployContract(deployer, artifacts.Treasury, [governor.address, registry.address])) as Treasury;
     await registry.connect(governor).setTreasury(treasury.address);
-    policyManager = (await deployContract(deployer, artifacts.PolicyManager, [governor.address])) as PolicyManager;
+    policyManager = (await deployContract(deployer, artifacts.PolicyManager, [governor.address, registry.address])) as PolicyManager;
     await registry.connect(governor).setPolicyManager(policyManager.address);
     riskManager = (await deployContract(deployer, artifacts.RiskManager, [governor.address, registry.address])) as RiskManager;
     await registry.connect(governor).setRiskManager(riskManager.address);

--- a/test/CpFarm.test.ts
+++ b/test/CpFarm.test.ts
@@ -72,7 +72,7 @@ describe("CpFarm", function () {
     await registry.connect(governor).setWeth(weth.address);
     vault = (await deployContract(deployer, artifacts.Vault, [governor.address, registry.address])) as Vault;
     await registry.connect(governor).setVault(vault.address);
-    policyManager = (await deployContract(deployer, artifacts.PolicyManager, [governor.address])) as PolicyManager;
+    policyManager = (await deployContract(deployer, artifacts.PolicyManager, [governor.address, registry.address])) as PolicyManager;
     await registry.connect(governor).setPolicyManager(policyManager.address);
     riskManager = (await deployContract(deployer, artifacts.RiskManager, [governor.address, registry.address])) as RiskManager;
     await registry.connect(governor).setRiskManager(riskManager.address);

--- a/test/Deployer.test.ts
+++ b/test/Deployer.test.ts
@@ -185,7 +185,7 @@ describe("Deployer", function () {
       await registry.setClaimsEscrow(claimsEscrow.address);
       treasury = (await deployContract(owner, artifacts.Treasury, [governor.address, registry.address])) as Treasury;
       await registry.setTreasury(treasury.address);
-      policyManager = (await deployContract(owner,artifacts.PolicyManager,[owner.address])) as PolicyManager;
+      policyManager = (await deployContract(owner,artifacts.PolicyManager,[owner.address, registry.address])) as PolicyManager;
       await registry.setPolicyManager(policyManager.address);
       riskManager = (await deployContract(owner, artifacts.RiskManager, [owner.address, registry.address])) as RiskManager;
       await registry.setRiskManager(riskManager.address);

--- a/test/FarmController.test.ts
+++ b/test/FarmController.test.ts
@@ -65,7 +65,7 @@ describe("FarmController", function () {
     await registry.connect(governor).setWeth(weth.address);
     vault = (await deployContract(deployer, artifacts.Vault, [governor.address, registry.address])) as Vault;
     await registry.connect(governor).setVault(vault.address);
-    policyManager = (await deployContract(deployer, artifacts.PolicyManager, [governor.address])) as PolicyManager;
+    policyManager = (await deployContract(deployer, artifacts.PolicyManager, [governor.address, registry.address])) as PolicyManager;
     await registry.connect(governor).setPolicyManager(policyManager.address);
     riskManager = (await deployContract(deployer, artifacts.RiskManager, [governor.address, registry.address])) as RiskManager;
     await registry.connect(governor).setRiskManager(riskManager.address);

--- a/test/FarmRewards.test.ts
+++ b/test/FarmRewards.test.ts
@@ -44,7 +44,7 @@ const PRICE_DAI = BN.from("30000000000000000").mul(SOLACE_PER_XSOLACE); // 3 cen
 const deadline = constants.MaxUint256;
 
 describe("FarmRewards", function () {
-  const [deployer, governor, farmer1, farmer2, trader, receiver] = provider.getWallets();
+  const [deployer, governor, farmer1, farmer2, trader, receiver, user] = provider.getWallets();
   let artifacts: ArtifactImports;
 
   before(async function () {
@@ -210,7 +210,7 @@ describe("FarmRewards", function () {
       await xsolace.connect(governor).transfer(farmRewards.address, ONE_MILLION_ETHER);
     });
     it("non farmer should not be eligible for rewards", async function () {
-      expect(await farmRewards.purchaseableVestedXSolace(trader.address)).eq(0);
+      expect(await farmRewards.purchaseableVestedXSolace(user.address)).eq(0);
     });
     it("farmer should be eligible for rewards", async function () {
       expect(await farmRewards.purchaseableVestedXSolace(farmer1.address)).gt(0);

--- a/test/OptionsFarming.test.ts
+++ b/test/OptionsFarming.test.ts
@@ -81,7 +81,7 @@ describe("OptionsFarming", function () {
     await registry.connect(governor).setWeth(weth.address);
     vault = (await deployContract(deployer, artifacts.Vault, [governor.address, registry.address])) as Vault;
     await registry.connect(governor).setVault(vault.address);
-    policyManager = (await deployContract(deployer, artifacts.PolicyManager, [governor.address])) as PolicyManager;
+    policyManager = (await deployContract(deployer, artifacts.PolicyManager, [governor.address, registry.address])) as PolicyManager;
     await registry.connect(governor).setPolicyManager(policyManager.address);
     riskManager = (await deployContract(deployer, artifacts.RiskManager, [governor.address, registry.address])) as RiskManager;
     await registry.connect(governor).setRiskManager(riskManager.address);

--- a/test/Registry.test.ts
+++ b/test/Registry.test.ts
@@ -156,7 +156,7 @@ describe("Registry", function() {
 
   describe("policyManager", function() {
     before(async function () {
-      policyManager = (await deployContract(deployer, artifacts.PolicyManager, [governor.address])) as PolicyManager;
+      policyManager = (await deployContract(deployer, artifacts.PolicyManager, [governor.address, registry.address])) as PolicyManager;
     });
     it("starts as the zero address", async function() {
       expect(await registry.policyManager()).to.equal(ZERO_ADDRESS);

--- a/test/SoteriaCoverageProduct.test.ts
+++ b/test/SoteriaCoverageProduct.test.ts
@@ -13,7 +13,6 @@ const provider: MockProvider = waffle.provider;
 dotenv_config();
 chai.use(solidity)
 
-const SUBMIT_CLAIM_TYPEHASH = utils.keccak256(utils.toUtf8Bytes("SoteriaCoverageProductSubmitClaim(uint256 policyID,address claimant,uint256 amountOut,uint256 deadline)"));
 const DOMAIN_NAME = "Solace.fi-SoteriaCoverageProduct";
 const VERSION = "1";
 
@@ -67,16 +66,22 @@ describe("SoteriaCoverageProduct", function() {
 
         solace = (await deployContract(deployer, artifacts.SOLACE, [governor.address])) as Solace;
         await registry.connect(governor).setSolace(solace.address);
+
         weth = (await deployContract(deployer, artifacts.WETH)) as Weth9;
         await registry.connect(governor).setWeth(weth.address);
+
         vault = (await deployContract(deployer, artifacts.Vault, [governor.address, registry.address])) as Vault;
         await registry.connect(governor).setVault(vault.address);
+
         claimsEscrow = (await deployContract(deployer, artifacts.ClaimsEscrow, [governor.address, registry.address])) as ClaimsEscrow;
         await registry.connect(governor).setClaimsEscrow(claimsEscrow.address);
+
         treasury = (await deployContract(deployer, artifacts.Treasury, [governor.address, registry.address])) as Treasury;
         await registry.connect(governor).setTreasury(treasury.address);
-        policyManager = (await deployContract(deployer, artifacts.PolicyManager, [governor.address])) as PolicyManager;
+
+        policyManager = (await deployContract(deployer, artifacts.PolicyManager, [governor.address, registry.address])) as PolicyManager;
         await registry.connect(governor).setPolicyManager(policyManager.address);
+
         riskManager = (await deployContract(deployer, artifacts.RiskManager, [governor.address, registry.address])) as RiskManager;
         await registry.connect(governor).setRiskManager(riskManager.address);
        
@@ -85,7 +90,6 @@ describe("SoteriaCoverageProduct", function() {
   
         coverageDataProvider = (await deployContract(deployer, artifacts.CoverageDataProvider, [governor.address, registry.address, priceOracle.address, solaceUsdcPool.address])) as CoverageDataProvider;
         await registry.connect(governor).setCoverageDataProvider(coverageDataProvider.address);
-
 
         await vault.connect(governor).addRequestor(claimsEscrow.address);
         await vault.connect(governor).addRequestor(treasury.address);
@@ -98,24 +102,19 @@ describe("SoteriaCoverageProduct", function() {
         });
 
         it("reverts for zero address registry", async () => {
-            await expect(deployContract(deployer, artifacts.SoteriaCoverageProduct, [governor.address, ZERO_ADDRESS, SUBMIT_CLAIM_TYPEHASH, DOMAIN_NAME, VERSION])).to.be.revertedWith("zero address registry");
+            await expect(deployContract(deployer, artifacts.SoteriaCoverageProduct, [governor.address, ZERO_ADDRESS, DOMAIN_NAME, VERSION])).to.be.revertedWith("zero address registry");
         });
 
         it("reverts for zero address riskmanager", async () => {
-            await expect(deployContract(deployer, artifacts.SoteriaCoverageProduct, [governor.address, mockRegistry.address, SUBMIT_CLAIM_TYPEHASH, DOMAIN_NAME, VERSION])).to.be.revertedWith("zero address riskmanager");
-        });
-
-        it("reverts for zero address policymanager", async () => {
-            await mockRegistry.connect(governor).setRiskManager(riskManager.address);
-            await expect(deployContract(deployer, artifacts.SoteriaCoverageProduct, [governor.address, mockRegistry.address, SUBMIT_CLAIM_TYPEHASH, DOMAIN_NAME, VERSION])).to.be.revertedWith("zero address policymanager");
+            await expect(deployContract(deployer, artifacts.SoteriaCoverageProduct, [governor.address, mockRegistry.address, DOMAIN_NAME, VERSION])).to.be.revertedWith("zero address riskmanager");
         });
 
         it("reverts for zero address governance", async () => {
-            await expect(deployContract(deployer, artifacts.SoteriaCoverageProduct, [ZERO_ADDRESS, registry.address , SUBMIT_CLAIM_TYPEHASH, DOMAIN_NAME, VERSION])).to.be.revertedWith("zero address governance");
+            await expect(deployContract(deployer, artifacts.SoteriaCoverageProduct, [ZERO_ADDRESS, registry.address , DOMAIN_NAME, VERSION])).to.be.revertedWith("zero address governance");
         });
 
         it("can deploy", async () => {
-            soteriaCoverageProduct = await deployContract(deployer, artifacts.SoteriaCoverageProduct, [governor.address, registry.address , SUBMIT_CLAIM_TYPEHASH, DOMAIN_NAME, VERSION]) as SoteriaCoverageProduct;
+            soteriaCoverageProduct = await deployContract(deployer, artifacts.SoteriaCoverageProduct, [governor.address, registry.address, DOMAIN_NAME, VERSION]) as SoteriaCoverageProduct;
             expect(soteriaCoverageProduct.address).to.not.undefined;
         });
     });
@@ -182,13 +181,10 @@ describe("SoteriaCoverageProduct", function() {
     describe("registry", () => {
         let registry2: Registry;
         let riskManager2: RiskManager;
-        let policyManager2: PolicyManager;
 
         before(async () => {
             registry2 =  (await deployContract(deployer, artifacts.Registry, [governor.address])) as Registry;
             riskManager2 = (await deployContract(deployer, artifacts.RiskManager, [governor.address, registry.address])) as RiskManager;
-            policyManager2 = (await deployContract(deployer, artifacts.PolicyManager, [governor.address])) as PolicyManager;
-
         });
 
         after(async () => {
@@ -216,13 +212,8 @@ describe("SoteriaCoverageProduct", function() {
             await expect(soteriaCoverageProduct.connect(governor).setRegistry(registry2.address)).to.revertedWith("zero address riskmanager");
         });
 
-        it("reverts for zero address policymanager", async () => {
-            await registry2.connect(governor).setRiskManager(riskManager2.address);
-            await expect(soteriaCoverageProduct.connect(governor).setRegistry(registry2.address)).to.revertedWith("zero address policymanager");
-        });
-
         it("governance can set registry", async () => {
-            await registry2.connect(governor).setPolicyManager(policyManager2.address);
+            await registry2.connect(governor).setRiskManager(riskManager2.address);
             let tx = await soteriaCoverageProduct.connect(governor).setRegistry(registry2.address);
             expect(tx).emit(soteriaCoverageProduct, "RegistrySet").withArgs(registry2.address);
             expect(await soteriaCoverageProduct.connect(policyholder1).riskManager()).to.equal(riskManager2.address);
@@ -277,17 +268,17 @@ describe("SoteriaCoverageProduct", function() {
     })
 
     describe("activatePolicy", () => {
-        let pmActiveCoverAmount:BN;
-        let pmSoteriaActiveCoverAmount: BN;
+        let rmActiveCoverAmount:BN;
+        let rmSoteriaActiveCoverAmount: BN;
         let mcr: BN;
         let mcrps: BN;
 
         before(async () => {
-            // policy manager active cover amount and active cover amount for soteria.
-            await policyManager.connect(governor).setSoteriaProduct(soteriaCoverageProduct.address);
-            expect(await policyManager.connect(governor).getSoteriaProduct()).to.equal(soteriaCoverageProduct.address);
-            pmActiveCoverAmount = await policyManager.connect(governor).activeCoverAmount();
-            pmSoteriaActiveCoverAmount = await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
+            await riskManager.connect(governor).addCoverLimitUpdater(soteriaCoverageProduct.address);
+
+            // risk manager active cover amount and active cover amount for soteria.
+            rmActiveCoverAmount = await riskManager.connect(governor).activeCoverLimit();
+            rmSoteriaActiveCoverAmount = await riskManager.connect(governor).activeCoverLimitPerStrategy(soteriaCoverageProduct.address);
 
             // risk manager min. capital requirement and min. capital requirement for soteria
             mcr = await riskManager.connect(governor).minCapitalRequirement();
@@ -353,7 +344,7 @@ describe("SoteriaCoverageProduct", function() {
             expect (await soteriaCoverageProduct.policyStatus(POLICY_ID_1)).eq(true)
             expect (await soteriaCoverageProduct.policyOf(policyholder1.address)).eq(POLICY_ID_1)
             expect (await soteriaCoverageProduct.ownerOf(POLICY_ID_1)).eq(policyholder1.address)
-            expect (await soteriaCoverageProduct.activeCoverLimit()).eq(ONE_ETH)
+            expect (await riskManager.activeCoverLimitPerStrategy(soteriaCoverageProduct.address)).eq(ONE_ETH)
             expect (await soteriaCoverageProduct.policyCount()).eq(1)
             expect (await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1)).eq(ONE_ETH)
             expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(ONE_ETH);
@@ -382,7 +373,7 @@ describe("SoteriaCoverageProduct", function() {
             expect (await soteriaCoverageProduct.policyStatus(POLICY_ID_2)).eq(true)
             expect (await soteriaCoverageProduct.policyOf(policyholder2.address)).eq(POLICY_ID_2)
             expect (await soteriaCoverageProduct.ownerOf(POLICY_ID_2)).eq(policyholder2.address)
-            expect (await soteriaCoverageProduct.activeCoverLimit()).eq(ONE_ETH.mul(2))
+            expect (await riskManager.activeCoverLimitPerStrategy(soteriaCoverageProduct.address)).eq(ONE_ETH.mul(2))
             expect (await soteriaCoverageProduct.policyCount()).eq(2)
             expect (await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2)).eq(ONE_ETH)
             expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(ONE_ETH.mul(2));
@@ -392,9 +383,9 @@ describe("SoteriaCoverageProduct", function() {
             expect(await soteriaCoverageProduct.connect(policyholder2).balanceOf(policyholder2.address)).to.equal(1);
         });
         it("should update policy manager active cover amount", async () => {
-            let activeCoverLimit = await soteriaCoverageProduct.activeCoverLimit();
-            expect(await policyManager.connect(governor).activeCoverAmount()).to.equal(pmActiveCoverAmount.add(activeCoverLimit));
-            expect(await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(pmSoteriaActiveCoverAmount.add(activeCoverLimit));
+            let activeCoverLimit = await riskManager.activeCoverLimitPerStrategy(soteriaCoverageProduct.address);
+            expect(await riskManager.connect(governor).activeCoverLimit()).to.equal(rmActiveCoverAmount.add(activeCoverLimit));
+            expect(await riskManager.connect(governor).activeCoverLimitPerStrategy(soteriaCoverageProduct.address)).to.equal(rmSoteriaActiveCoverAmount.add(activeCoverLimit));
         });
         it("should update risk manager mcr", async () => {
             let activeCoverLimit = await soteriaCoverageProduct.connect(governor).activeCoverLimit();
@@ -484,21 +475,25 @@ describe("SoteriaCoverageProduct", function() {
             let policyholderETHBalance = await provider.getBalance(policyholder1.address)
             let soteriaETHBalance = await provider.getBalance(soteriaCoverageProduct.address)
             let policyCoverLimit = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1);
-            let activeCoverLimit = await soteriaCoverageProduct.activeCoverLimit();
+            let activeCoverLimit = await riskManager.activeCoverLimitPerStrategy(soteriaCoverageProduct.address);
 
+            const maxRateNum = await soteriaCoverageProduct.maxRateNum();
+            const chargeCycle = await soteriaCoverageProduct.chargeCycle();
+            const maxRateDenom = await soteriaCoverageProduct.maxRateDenom();
+            let minRequiredAccountBalance = maxRateNum.mul(chargeCycle).mul(policyCoverLimit).div(maxRateDenom);            
+            expect(minRequiredAccountBalance).to.lt(accountBalance.sub(1));
             let tx = await soteriaCoverageProduct.connect(policyholder1).withdraw(accountBalance.sub(1));
 
             let receipt = await tx.wait();
             let gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice);
             await expect(tx).emit(soteriaCoverageProduct, "PolicyDeactivated").withArgs(POLICY_ID_1);
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(activeCoverLimit.sub(policyCoverLimit));
             expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(0);
             expect(await provider.getBalance(policyholder1.address)).eq(policyholderETHBalance.add(accountBalance).sub(gasCost))
             expect(await provider.getBalance(soteriaCoverageProduct.address)).eq(soteriaETHBalance.sub(accountBalance))
             expect (await soteriaCoverageProduct.policyStatus(POLICY_ID_1)).eq(false)
             expect (await soteriaCoverageProduct.ownerOf(POLICY_ID_1)).eq(policyholder1.address)
             expect (await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1)).eq(0)
-            expect (await soteriaCoverageProduct.activeCoverLimit()).eq(activeCoverLimit.sub(policyCoverLimit))
+            expect (await riskManager.activeCoverLimitPerStrategy(soteriaCoverageProduct.address)).eq(activeCoverLimit.sub(policyCoverLimit))
             expect (await soteriaCoverageProduct.policyCount()).eq(2)
         })
         after(async () => {
@@ -510,7 +505,7 @@ describe("SoteriaCoverageProduct", function() {
         })
     });
 
-    describe("updateCoverAmount", () => {
+    describe("updateCoverLimit", () => {
         let maxCover: BN;
         let maxCoverPerStrategy: BN;
         let initialMCRForSoteria: BN;
@@ -529,8 +524,8 @@ describe("SoteriaCoverageProduct", function() {
             initialMCRForSoteria = await riskManager.connect(governor).minCapitalRequirementPerStrategy(soteriaCoverageProduct.address);
             
             // policy manager current values
-            initialPMActiveCoverLimit = await policyManager.connect(governor).activeCoverAmount();
-            initialPMActiveCoverLimitForSoteria = await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
+            initialPMActiveCoverLimit = await riskManager.connect(governor).activeCoverLimit();
+            initialPMActiveCoverLimitForSoteria = await riskManager.connect(governor).activeCoverLimitPerStrategy(soteriaCoverageProduct.address);
 
             initialSoteriaActiveCoverLimit = await soteriaCoverageProduct.connect(policyholder1).activeCoverLimit();
             initialPolicyCoverLimit = await soteriaCoverageProduct.connect(policyholder1).coverLimitOf(POLICY_ID_1);
@@ -579,7 +574,6 @@ describe("SoteriaCoverageProduct", function() {
             let tx = await soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, NEW_COVER_LIMIT);
 
             await expect(tx).emit(soteriaCoverageProduct, "PolicyUpdated").withArgs(POLICY_ID_1);
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(activeCoverLimit);
             expect(await soteriaCoverageProduct.connect(policyholder1).activeCoverLimit()).to.equal(activeCoverLimit);
             expect(await soteriaCoverageProduct.connect(policyholder1).coverLimitOf(POLICY_ID_1)).to.equal(NEW_COVER_LIMIT);
         });
@@ -591,7 +585,6 @@ describe("SoteriaCoverageProduct", function() {
             let tx = await soteriaCoverageProduct.connect(governor).updateCoverLimit(POLICY_ID_1, TEST_COVER_LIMIT);
 
             await expect(tx).emit(soteriaCoverageProduct, "PolicyUpdated").withArgs(POLICY_ID_1);
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(activeCoverLimit);
             expect(await soteriaCoverageProduct.connect(policyholder1).activeCoverLimit()).to.equal(activeCoverLimit);
             expect(await soteriaCoverageProduct.connect(policyholder1).coverLimitOf(POLICY_ID_1)).to.equal(TEST_COVER_LIMIT);
 
@@ -599,12 +592,12 @@ describe("SoteriaCoverageProduct", function() {
             await soteriaCoverageProduct.connect(governor).updateCoverLimit(POLICY_ID_1, NEW_COVER_LIMIT);
         });
 
-        it("should update policy manager active cover limit", async () => {
+        it("should update risk manager active cover limit", async () => {
             let amount1 = initialPMActiveCoverLimit.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
             let amount2 = initialPMActiveCoverLimitForSoteria.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
 
-            expect(await policyManager.connect(governor).activeCoverAmount()).to.equal(amount1);
-            expect(await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(amount2);
+            expect(await riskManager.connect(governor).activeCoverLimit()).to.equal(amount1);
+            expect(await riskManager.connect(governor).activeCoverLimitPerStrategy(soteriaCoverageProduct.address)).to.equal(amount2);
         });
 
         it("should update risk manager mcr", async () => {         
@@ -633,15 +626,14 @@ describe("SoteriaCoverageProduct", function() {
             let initialPolicyholderETHBalance = await policyholder3.getBalance();
             let initialPolicyholderAccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)
             let initialPolicyCoverLimit = await soteriaCoverageProduct.connect(policyholder3).coverLimitOf(POLICY_ID_3);
-            let initialActiveCoverLimit = await soteriaCoverageProduct.connect(policyholder3).activeCoverLimit();
+            let initialActiveCoverLimit = await riskManager.connect(policyholder3).activeCoverLimit();
             let initialAvailableCoverCapacity = await soteriaCoverageProduct.availableCoverCapacity();
-            let initialPMActiveCoverAmount = await policyManager.connect(policyholder3).activeCoverAmount();
-            let initialPMActiveCoverAmountForSoteria = await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
+            let initialPMActiveCoverAmount = await riskManager.connect(policyholder3).activeCoverLimit();
+            let initialPMActiveCoverAmountForSoteria = await riskManager.connect(policyholder3).activeCoverLimitPerStrategy(soteriaCoverageProduct.address);
 
             // deactivate policy
             let tx = await soteriaCoverageProduct.connect(policyholder3).deactivatePolicy(POLICY_ID_3);
             await expect(tx).emit(soteriaCoverageProduct, "PolicyDeactivated").withArgs(POLICY_ID_3);
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
 
             // user should get refunds
             let receipt = await tx.wait();
@@ -650,7 +642,7 @@ describe("SoteriaCoverageProduct", function() {
             expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).to.equal(ZERO_AMOUNT);
 
             // soteria active cover amount should be decreased
-            expect(await soteriaCoverageProduct.activeCoverLimit()).to.equal(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
+            expect(await riskManager.activeCoverLimitPerStrategy(soteriaCoverageProduct.address)).to.equal(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
 
             // cover limit should be zero
             expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_3)).to.equal(ZERO_AMOUNT);
@@ -661,8 +653,8 @@ describe("SoteriaCoverageProduct", function() {
             expect(await soteriaCoverageProduct.policyCount()).eq(3)
 
             // policy manager active cover amount and active cover amount for soteria should be decreased
-            expect(await policyManager.connect(policyholder3).activeCoverAmount()).to.equal(initialPMActiveCoverAmount.sub(initialPolicyCoverLimit));
-            expect(await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(initialPMActiveCoverAmountForSoteria.sub(initialPolicyCoverLimit));
+            expect(await riskManager.connect(policyholder3).activeCoverLimit()).to.equal(initialPMActiveCoverAmount.sub(initialPolicyCoverLimit));
+            expect(await riskManager.connect(policyholder3).activeCoverLimitPerStrategy(soteriaCoverageProduct.address)).to.equal(initialPMActiveCoverAmountForSoteria.sub(initialPolicyCoverLimit));
 
             // revert for next unit test - governor can deactivate policy
             await policyholder3.sendTransaction({ to: soteriaCoverageProduct.address, value: initialPolicyholderAccountBalance });
@@ -671,8 +663,8 @@ describe("SoteriaCoverageProduct", function() {
             expect(await soteriaCoverageProduct.connect(policyholder3).coverLimitOf(POLICY_ID_3)).eq(initialPolicyCoverLimit)
             expect(await soteriaCoverageProduct.connect(policyholder3).activeCoverLimit()).eq(initialActiveCoverLimit)
             expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity)
-            expect(await policyManager.connect(policyholder3).activeCoverAmount()).eq(initialPMActiveCoverAmount)
-            expect(await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).eq(initialPMActiveCoverAmountForSoteria)
+            expect(await riskManager.connect(policyholder3).activeCoverLimit()).eq(initialPMActiveCoverAmount)
+            expect(await riskManager.connect(policyholder3).activeCoverLimitPerStrategy(soteriaCoverageProduct.address)).eq(initialPMActiveCoverAmountForSoteria)
         });
 
         it("governor can deactivate policy", async () => {
@@ -681,13 +673,12 @@ describe("SoteriaCoverageProduct", function() {
             let initialPolicyCoverLimit = await soteriaCoverageProduct.connect(policyholder3).coverLimitOf(POLICY_ID_3);
             let initialActiveCoverLimit = await soteriaCoverageProduct.connect(policyholder3).activeCoverLimit();
             let initialAvailableCoverCapacity = await soteriaCoverageProduct.availableCoverCapacity();
-            let initialPMActiveCoverAmount = await policyManager.connect(policyholder3).activeCoverAmount();
-            let initialPMActiveCoverAmountForSoteria = await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
+            let initialRMActiveCoverLimit = await riskManager.connect(policyholder3).activeCoverLimit();
+            let initialRMActiveCoverLimitForSoteria = await riskManager.connect(policyholder3).activeCoverLimitPerStrategy(soteriaCoverageProduct.address);
 
             // deactivate policy
             let tx = await soteriaCoverageProduct.connect(governor).deactivatePolicy(POLICY_ID_3);
             await expect(tx).emit(soteriaCoverageProduct, "PolicyDeactivated").withArgs(POLICY_ID_3);
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
 
             // user should get refunds
             let receipt = await tx.wait();
@@ -696,7 +687,7 @@ describe("SoteriaCoverageProduct", function() {
             expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).to.equal(ZERO_AMOUNT);
 
             // soteria active cover amount should be decreased
-            expect(await soteriaCoverageProduct.activeCoverLimit()).to.equal(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
+            expect(await riskManager.activeCoverLimitPerStrategy(soteriaCoverageProduct.address)).to.equal(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
 
             // cover limit should be zero
             expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_3)).to.equal(ZERO_AMOUNT);
@@ -707,8 +698,8 @@ describe("SoteriaCoverageProduct", function() {
             expect(await soteriaCoverageProduct.policyCount()).eq(3)
 
             // policy manager active cover amount and active cover amount for soteria should be decreased
-            expect(await policyManager.connect(policyholder3).activeCoverAmount()).to.equal(initialPMActiveCoverAmount.sub(initialPolicyCoverLimit));
-            expect(await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(initialPMActiveCoverAmountForSoteria.sub(initialPolicyCoverLimit));
+            expect(await riskManager.connect(policyholder3).activeCoverLimit()).to.equal(initialRMActiveCoverLimit.sub(initialPolicyCoverLimit));
+            expect(await riskManager.connect(policyholder3).activeCoverLimitPerStrategy(soteriaCoverageProduct.address)).to.equal(initialRMActiveCoverLimitForSoteria.sub(initialPolicyCoverLimit));
 
             // revert for next unit test - governor can deactivate policy
             await soteriaCoverageProduct.connect(governor).deposit(policyholder3.address, {value: initialPolicyholderAccountBalance})
@@ -717,8 +708,8 @@ describe("SoteriaCoverageProduct", function() {
             expect(await soteriaCoverageProduct.connect(policyholder3).coverLimitOf(POLICY_ID_3)).eq(initialPolicyCoverLimit)
             expect(await soteriaCoverageProduct.connect(policyholder3).activeCoverLimit()).eq(initialActiveCoverLimit)
             expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity)
-            expect(await policyManager.connect(policyholder3).activeCoverAmount()).eq(initialPMActiveCoverAmount)
-            expect(await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).eq(initialPMActiveCoverAmountForSoteria)
+            expect(await riskManager.connect(policyholder3).activeCoverLimit()).eq(initialRMActiveCoverLimit)
+            expect(await riskManager.connect(policyholder3).activeCoverLimitPerStrategy(soteriaCoverageProduct.address)).eq(initialRMActiveCoverLimitForSoteria)
         });
     });
 
@@ -749,7 +740,7 @@ describe("SoteriaCoverageProduct", function() {
             let policyholder2AccountBalance = await soteriaCoverageProduct.connect(policyholder1).accountBalanceOf(policyholder2.address);
             let initialCoverLimit1 = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1);
             let initialCoverLimit2 = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2);
-            let initialActiveCoverLimit = await soteriaCoverageProduct.activeCoverLimit();
+            let initialActiveCoverLimit = await riskManager.activeCoverLimitPerStrategy(soteriaCoverageProduct.address);
             let initialActiveCoverCapacity = await soteriaCoverageProduct.availableCoverCapacity();
 
             // charge premiums
@@ -771,7 +762,7 @@ describe("SoteriaCoverageProduct", function() {
             // following mappings should be unchanged
             expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1)).eq(initialCoverLimit1)
             expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2)).eq(initialCoverLimit2)
-            expect(await soteriaCoverageProduct.activeCoverLimit()).eq(initialActiveCoverLimit)
+            expect(await riskManager.activeCoverLimitPerStrategy(soteriaCoverageProduct.address)).eq(initialActiveCoverLimit)
         });
 
         it("can partially charge premiums if the fund is insufficient", async () => {
@@ -790,8 +781,8 @@ describe("SoteriaCoverageProduct", function() {
             let initialActiveCoverLimit = await soteriaCoverageProduct.connect(policyholder4).activeCoverLimit();
             let initialPolicyCoverLimit = await soteriaCoverageProduct.connect(policyholder4).coverLimitOf(POLICY_ID_4);
             let initialAvailableCoverCapacity = await soteriaCoverageProduct.connect(policyholder4).availableCoverCapacity();
-            let initialPMCoverAmount = await policyManager.connect(policyholder4).activeCoverAmount();
-            let initialPMSoteriaCoverAmount = await policyManager.connect(policyholder4).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
+            let initialRMCoverLimit = await riskManager.connect(policyholder4).activeCoverLimit();
+            let initialRMSoteriaCoverLimit = await riskManager.connect(policyholder4).activeCoverLimitPerStrategy(soteriaCoverageProduct.address);
 
             // we cannot reach the PremiumPartiallyCharged branch within a single chargePremiums() call
             await soteriaCoverageProduct.connect(governor).chargePremiums([policyholder4.address], [WEEKLY_MAX_PREMIUM]);
@@ -811,9 +802,9 @@ describe("SoteriaCoverageProduct", function() {
             expect(await soteriaCoverageProduct.connect(user).coverLimitOf(POLICY_ID_4)).to.equal(ZERO_AMOUNT);
 
             // policy manager should be updated
-            expect(await policyManager.connect(user).activeCoverAmount()).to.equal(initialPMCoverAmount.sub(initialPolicyCoverLimit));
-            expect(await policyManager.connect(user).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(initialPMSoteriaCoverAmount.sub(initialPolicyCoverLimit));
-            expect(await policyManager.connect(user).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
+            expect(await riskManager.connect(user).activeCoverLimit()).to.equal(initialRMCoverLimit.sub(initialPolicyCoverLimit));
+            expect(await riskManager.connect(user).activeCoverLimitPerStrategy(soteriaCoverageProduct.address)).to.equal(initialRMSoteriaCoverLimit.sub(initialPolicyCoverLimit));
+            expect(await riskManager.connect(user).activeCoverLimitPerStrategy(soteriaCoverageProduct.address)).to.equal(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
 
             // policyholder funds should be zero
             expect(await soteriaCoverageProduct.connect(user).accountBalanceOf(policyholder4.address)).to.equal(ZERO_AMOUNT);
@@ -886,13 +877,13 @@ describe("SoteriaCoverageProduct", function() {
             let initialHolder1AccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
             let initialHolder2AccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder2.address);
             let initialHolder3AccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder3.address);
-            let initialActiveCoverLimit = await soteriaCoverageProduct.activeCoverLimit();
+            let initialActiveCoverLimit = await riskManager.activeCoverLimitPerStrategy(soteriaCoverageProduct.address);
             let initialPolicy1CoverLimit = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1);
             let initialPolicy2CoverLimit = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2);
             let initialPolicy3CoverLimit = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_3);
             let initialAvailableCoverCapacity = await soteriaCoverageProduct.availableCoverCapacity();
-            let initialPMCoverAmount = await policyManager.activeCoverAmount();
-            let initialPMSoteriaCoverAmount = await policyManager.activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
+            let initialRMCoverAmount = await riskManager.activeCoverLimit();
+            let initialRMSoteriaCoverAmount = await riskManager.activeCoverLimitPerStrategy(soteriaCoverageProduct.address);
 
             tx = await soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address, policyholder3.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM])
             expect(tx).to.emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder1.address, WEEKLY_MAX_PREMIUM);
@@ -933,9 +924,9 @@ describe("SoteriaCoverageProduct", function() {
             expect(await provider.getBalance(vault.address)).eq(initialVaultBalance.add(expectedSoteriaBalanceChange))
 
             // Soteria active cover limit check - policy 3 deactivated
-            expect(await soteriaCoverageProduct.activeCoverLimit()).eq(initialActiveCoverLimit.sub(initialPolicy3CoverLimit))
-            expect(await policyManager.activeCoverAmount()).eq(initialPMCoverAmount.sub(initialPolicy3CoverLimit))
-            expect(await policyManager.activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).eq(initialPMSoteriaCoverAmount.sub(initialPolicy3CoverLimit))
+            expect(await riskManager.activeCoverLimitPerStrategy(soteriaCoverageProduct.address)).eq(initialActiveCoverLimit.sub(initialPolicy3CoverLimit))
+            expect(await riskManager.activeCoverLimit()).eq(initialRMCoverAmount.sub(initialPolicy3CoverLimit))
+            expect(await riskManager.activeCoverLimitPerStrategy(soteriaCoverageProduct.address)).eq(initialRMSoteriaCoverAmount.sub(initialPolicy3CoverLimit))
             
             // Cover capacity check - maxCover() increased by vault deposits, active cover limit decreased by policy 3 initial cover limit
             expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity.add(expectedSoteriaBalanceChange).add(initialPolicy3CoverLimit))
@@ -974,8 +965,6 @@ describe("SoteriaCoverageProduct", function() {
             // Charge premiums
             await soteriaCoverageProduct.connect(governor).chargePremiums(ADDRESS_ARRAY, PREMIUM_ARRAY);
         })
-    // Test for maxing out users
-
     });
 
 });

--- a/test/SoteriaCoverageProduct.test.ts
+++ b/test/SoteriaCoverageProduct.test.ts
@@ -331,6 +331,9 @@ describe("SoteriaCoverageProduct", function() {
         it("cannot be set by non governance", async () => {
             await expect(soteriaCoverageProduct.connect(policyholder1).setReferralRewardPercentage(REFERRAL_REWARD_PERCENTAGE)).to.revertedWith("!governance");
         });
+        it("cannot be over 10000", async () => {
+            await expect(soteriaCoverageProduct.connect(governor).setReferralRewardPercentage(BN.from("10001"))).to.revertedWith("cannot set over 100%");
+        });
         it("can be set", async () => {
             let tx = await soteriaCoverageProduct.connect(governor).setReferralRewardPercentage(REFERRAL_REWARD_PERCENTAGE)
             expect(tx).emit(soteriaCoverageProduct, "ReferralRewardPercentageSet").withArgs(REFERRAL_REWARD_PERCENTAGE);

--- a/test/SoteriaCoverageProduct.test.ts
+++ b/test/SoteriaCoverageProduct.test.ts
@@ -276,706 +276,706 @@ describe("SoteriaCoverageProduct", function() {
         })
     })
 
-    // describe("activatePolicy", () => {
-    //     let pmActiveCoverAmount:BN;
-    //     let pmSoteriaActiveCoverAmount: BN;
-    //     let mcr: BN;
-    //     let mcrps: BN;
+    describe("activatePolicy", () => {
+        let pmActiveCoverAmount:BN;
+        let pmSoteriaActiveCoverAmount: BN;
+        let mcr: BN;
+        let mcrps: BN;
 
-    //     before(async () => {
-    //         // policy manager active cover amount and active cover amount for soteria.
-    //         await policyManager.connect(governor).setSoteriaProduct(soteriaCoverageProduct.address);
-    //         expect(await policyManager.connect(governor).getSoteriaProduct()).to.equal(soteriaCoverageProduct.address);
-    //         pmActiveCoverAmount = await policyManager.connect(governor).activeCoverAmount();
-    //         pmSoteriaActiveCoverAmount = await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
+        before(async () => {
+            // policy manager active cover amount and active cover amount for soteria.
+            await policyManager.connect(governor).setSoteriaProduct(soteriaCoverageProduct.address);
+            expect(await policyManager.connect(governor).getSoteriaProduct()).to.equal(soteriaCoverageProduct.address);
+            pmActiveCoverAmount = await policyManager.connect(governor).activeCoverAmount();
+            pmSoteriaActiveCoverAmount = await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
 
-    //         // risk manager min. capital requirement and min. capital requirement for soteria
-    //         mcr = await riskManager.connect(governor).minCapitalRequirement();
-    //         mcrps = await riskManager.connect(governor).minCapitalRequirementPerStrategy(soteriaCoverageProduct.address);
-    //     });
+            // risk manager min. capital requirement and min. capital requirement for soteria
+            mcr = await riskManager.connect(governor).minCapitalRequirement();
+            mcrps = await riskManager.connect(governor).minCapitalRequirementPerStrategy(soteriaCoverageProduct.address);
+        });
 
-    //     it("cannot activate policy when zero address policy holder is provided", async () => {
-    //         await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(ZERO_ADDRESS, INITIAL_COVER_LIMIT)).to.revertedWith("zero address policyholder");
-    //     });
+        it("cannot activate policy when zero address policy holder is provided", async () => {
+            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(ZERO_ADDRESS, INITIAL_COVER_LIMIT)).to.revertedWith("zero address policyholder");
+        });
 
-    //     it("cannot buy policy when zero cover amount value is provided", async () => {
-    //         await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, ZERO_AMOUNT)).to.revertedWith("zero cover value");
-    //     });
+        it("cannot buy policy when zero cover amount value is provided", async () => {
+            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, ZERO_AMOUNT)).to.revertedWith("zero cover value");
+        });
 
-    //     it("cannot buy policy when contract is paused", async () => {
-    //         await soteriaCoverageProduct.connect(governor).setPaused(true);
-    //         await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, INITIAL_COVER_LIMIT, {value: ONE_ETH})).to.revertedWith("contract paused");
-    //         await soteriaCoverageProduct.connect(governor).setPaused(false);
-    //     });
+        it("cannot buy policy when contract is paused", async () => {
+            await soteriaCoverageProduct.connect(governor).setPaused(true);
+            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, INITIAL_COVER_LIMIT, {value: ONE_ETH})).to.revertedWith("contract paused");
+            await soteriaCoverageProduct.connect(governor).setPaused(false);
+        });
 
-    //     it("can cannot purchase a policy before Coverage Data Provider and Risk Manager are set up (maxCover = 0)", async () => {
-    //         expect (await soteriaCoverageProduct.maxCover()).eq(0)
-    //         await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, INITIAL_COVER_LIMIT, {value: ZERO_AMOUNT})).to.revertedWith("insufficient capacity for new cover");
-    //     })
+        it("can cannot purchase a policy before Coverage Data Provider and Risk Manager are set up (maxCover = 0)", async () => {
+            expect (await soteriaCoverageProduct.maxCover()).eq(0)
+            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, INITIAL_COVER_LIMIT, {value: ZERO_AMOUNT})).to.revertedWith("insufficient capacity for new cover");
+        })
 
-    //     it("can setup Coverage Data Provider and Risk Manager", async () => {
-    //         // add underwriting pool to the coverage data provider
-    //         let maxCover1 = await riskManager.connect(governor).maxCover();
-    //         expect(maxCover1).to.equal(0)
-    //         expect(await coverageDataProvider.connect(governor).numOfPools()).to.equal(0);
+        it("can setup Coverage Data Provider and Risk Manager", async () => {
+            // add underwriting pool to the coverage data provider
+            let maxCover1 = await riskManager.connect(governor).maxCover();
+            expect(maxCover1).to.equal(0)
+            expect(await coverageDataProvider.connect(governor).numOfPools()).to.equal(0);
 
-    //         await coverageDataProvider.connect(governor).addPools([underwritingPool.address]);
-    //         expect(await coverageDataProvider.connect(governor).numOfPools()).to.equal(1);
-    //         let uwpETHBalance = await underwritingPool.getBalance();
-    //         let maxCover2 = await riskManager.connect(governor).maxCover();
-    //         expect(maxCover2).to.equal(maxCover1.add(uwpETHBalance));
+            await coverageDataProvider.connect(governor).addPools([underwritingPool.address]);
+            expect(await coverageDataProvider.connect(governor).numOfPools()).to.equal(1);
+            let uwpETHBalance = await underwritingPool.getBalance();
+            let maxCover2 = await riskManager.connect(governor).maxCover();
+            expect(maxCover2).to.equal(maxCover1.add(uwpETHBalance));
             
-    //         // add Soteria to the risk manager and assign coverage allocation
-    //         await riskManager.connect(governor).addRiskStrategy(soteriaCoverageProduct.address);
-    //         await riskManager.connect(governor).setStrategyStatus(soteriaCoverageProduct.address, STRATEGY_STATUS.ACTIVE);
-    //         await riskManager.connect(governor).setWeightAllocation(soteriaCoverageProduct.address, 1000);
-    //         expect(await riskManager.connect(governor).maxCoverPerStrategy(soteriaCoverageProduct.address)).to.equal(maxCover2);
-    //         expect(await riskManager.connect(governor).maxCoverPerStrategy(soteriaCoverageProduct.address)).to.equal(await soteriaCoverageProduct.maxCover());
-    //     })
+            // add Soteria to the risk manager and assign coverage allocation
+            await riskManager.connect(governor).addRiskStrategy(soteriaCoverageProduct.address);
+            await riskManager.connect(governor).setStrategyStatus(soteriaCoverageProduct.address, STRATEGY_STATUS.ACTIVE);
+            await riskManager.connect(governor).setWeightAllocation(soteriaCoverageProduct.address, 1000);
+            expect(await riskManager.connect(governor).maxCoverPerStrategy(soteriaCoverageProduct.address)).to.equal(maxCover2);
+            expect(await riskManager.connect(governor).maxCoverPerStrategy(soteriaCoverageProduct.address)).to.equal(await soteriaCoverageProduct.maxCover());
+        })
 
-    //     it("cannot buy policy when max cover exceeded", async () => {
-    //         let maxCover = await soteriaCoverageProduct.maxCover();
-    //         await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, maxCover.add(1), {value: ONE_ETH})).to.revertedWith("insufficient capacity for new cover");
-    //     });
+        it("cannot buy policy when max cover exceeded", async () => {
+            let maxCover = await soteriaCoverageProduct.maxCover();
+            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, maxCover.add(1), {value: ONE_ETH})).to.revertedWith("insufficient capacity for new cover");
+        });
 
-    //     it("cannot buy policy when insufficient deposit provided", async () => {
-    //         await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, ONE_ETH, {value: ZERO_AMOUNT})).to.revertedWith("insufficient deposit for minimum required account balance");
-    //     });
+        it("cannot buy policy when insufficient deposit provided", async () => {
+            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, ONE_ETH, {value: ZERO_AMOUNT})).to.revertedWith("insufficient deposit for minimum required account balance");
+        });
 
-    //     it("can activate policy - 1 ETH cover with 1 ETH deposit", async () => {
-    //         let tx = await soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, ONE_ETH, {value: ONE_ETH});
+        it("can activate policy - 1 ETH cover with 1 ETH deposit", async () => {
+            let tx = await soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, ONE_ETH, {value: ONE_ETH});
 
-    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyCreated").withArgs(POLICY_ID_1);
-    //         await expect(tx).emit(soteriaCoverageProduct, "Transfer").withArgs(ZERO_ADDRESS, policyholder1.address, POLICY_ID_1);
+            await expect(tx).emit(soteriaCoverageProduct, "PolicyCreated").withArgs(POLICY_ID_1);
+            await expect(tx).emit(soteriaCoverageProduct, "Transfer").withArgs(ZERO_ADDRESS, policyholder1.address, POLICY_ID_1);
 
-    //         expect (await soteriaCoverageProduct.rewardPointsOf(policyholder1.address)).eq(0)
-    //         expect (await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).eq(ONE_ETH)
-    //         expect (await soteriaCoverageProduct.policyStatus(POLICY_ID_1)).eq(true)
-    //         expect (await soteriaCoverageProduct.policyOf(policyholder1.address)).eq(POLICY_ID_1)
-    //         expect (await soteriaCoverageProduct.ownerOf(POLICY_ID_1)).eq(policyholder1.address)
-    //         expect (await soteriaCoverageProduct.activeCoverLimit()).eq(ONE_ETH)
-    //         expect (await soteriaCoverageProduct.policyCount()).eq(1)
-    //         expect (await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1)).eq(ONE_ETH)
-    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(ONE_ETH);
-    //     });
+            expect (await soteriaCoverageProduct.rewardPointsOf(policyholder1.address)).eq(0)
+            expect (await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).eq(ONE_ETH)
+            expect (await soteriaCoverageProduct.policyStatus(POLICY_ID_1)).eq(true)
+            expect (await soteriaCoverageProduct.policyOf(policyholder1.address)).eq(POLICY_ID_1)
+            expect (await soteriaCoverageProduct.ownerOf(POLICY_ID_1)).eq(policyholder1.address)
+            expect (await soteriaCoverageProduct.activeCoverLimit()).eq(ONE_ETH)
+            expect (await soteriaCoverageProduct.policyCount()).eq(1)
+            expect (await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1)).eq(ONE_ETH)
+            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(ONE_ETH);
+        });
 
-    //     it("cannot purchase more than one policy for a single address", async () => {
-    //         await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, ONE_ETH, {value: ONE_ETH})).to.be.revertedWith("policy already activated")
-    //         await expect(soteriaCoverageProduct.connect(policyholder2).activatePolicy(policyholder1.address, ONE_ETH, {value: ONE_ETH})).to.be.revertedWith("policy already activated")
-    //     })
+        it("cannot purchase more than one policy for a single address", async () => {
+            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, ONE_ETH, {value: ONE_ETH})).to.be.revertedWith("policy already activated")
+            await expect(soteriaCoverageProduct.connect(policyholder2).activatePolicy(policyholder1.address, ONE_ETH, {value: ONE_ETH})).to.be.revertedWith("policy already activated")
+        })
         
-    //     it("cannot transfer policy", async () => {
-    //         await expect(soteriaCoverageProduct.connect(policyholder1).transferFrom(policyholder1.address, policyholder2.address, 1)).to.be.revertedWith("only minting permitted");
-    //         await expect(soteriaCoverageProduct.connect(policyholder1).transferFrom(policyholder1.address, ZERO_ADDRESS, 1)).to.be.revertedWith("ERC721: transfer to the zero address");
-    //         // TO-DO, test ERC721.safeTransferFrom() => TypeError: soteriaCoverageProduct.connect(...).safeTransferFrom is not a function
-    //     })
+        it("cannot transfer policy", async () => {
+            await expect(soteriaCoverageProduct.connect(policyholder1).transferFrom(policyholder1.address, policyholder2.address, 1)).to.be.revertedWith("only minting permitted");
+            await expect(soteriaCoverageProduct.connect(policyholder1).transferFrom(policyholder1.address, ZERO_ADDRESS, 1)).to.be.revertedWith("ERC721: transfer to the zero address");
+            // TO-DO, test ERC721.safeTransferFrom() => TypeError: soteriaCoverageProduct.connect(...).safeTransferFrom is not a function
+        })
 
-    //     it("can activate policy for another address - 1 ETH cover with 1 ETH deposit", async () => {
-    //         let tx = await soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder2.address, ONE_ETH, {value: ONE_ETH});
+        it("can activate policy for another address - 1 ETH cover with 1 ETH deposit", async () => {
+            let tx = await soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder2.address, ONE_ETH, {value: ONE_ETH});
 
-    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyCreated").withArgs(POLICY_ID_2);
-    //         await expect(tx).emit(soteriaCoverageProduct, "Transfer").withArgs(ZERO_ADDRESS, policyholder2.address, POLICY_ID_2);
+            await expect(tx).emit(soteriaCoverageProduct, "PolicyCreated").withArgs(POLICY_ID_2);
+            await expect(tx).emit(soteriaCoverageProduct, "Transfer").withArgs(ZERO_ADDRESS, policyholder2.address, POLICY_ID_2);
 
-    //         expect (await soteriaCoverageProduct.rewardPointsOf(policyholder2.address)).eq(0)
-    //         expect (await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).eq(ONE_ETH)
-    //         expect (await soteriaCoverageProduct.accountBalanceOf(policyholder2.address)).eq(ONE_ETH)
-    //         expect (await soteriaCoverageProduct.policyStatus(POLICY_ID_2)).eq(true)
-    //         expect (await soteriaCoverageProduct.policyOf(policyholder2.address)).eq(POLICY_ID_2)
-    //         expect (await soteriaCoverageProduct.ownerOf(POLICY_ID_2)).eq(policyholder2.address)
-    //         expect (await soteriaCoverageProduct.activeCoverLimit()).eq(ONE_ETH.mul(2))
-    //         expect (await soteriaCoverageProduct.policyCount()).eq(2)
-    //         expect (await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2)).eq(ONE_ETH)
-    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(ONE_ETH.mul(2));
-    //     });
-    //     it("policy holder should have policy nft after buying coverage", async () => {
-    //         expect(await soteriaCoverageProduct.connect(policyholder1).balanceOf(policyholder1.address)).to.equal(1);
-    //         expect(await soteriaCoverageProduct.connect(policyholder2).balanceOf(policyholder2.address)).to.equal(1);
-    //     });
-    //     it("should update policy manager active cover amount", async () => {
-    //         let activeCoverLimit = await soteriaCoverageProduct.activeCoverLimit();
-    //         expect(await policyManager.connect(governor).activeCoverAmount()).to.equal(pmActiveCoverAmount.add(activeCoverLimit));
-    //         expect(await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(pmSoteriaActiveCoverAmount.add(activeCoverLimit));
-    //     });
-    //     it("should update risk manager mcr", async () => {
-    //         let activeCoverLimit = await soteriaCoverageProduct.connect(governor).activeCoverLimit();
-    //         expect(await riskManager.connect(governor).minCapitalRequirement()).to.equal(mcr.add(activeCoverLimit));
-    //         expect(await riskManager.connect(governor).minCapitalRequirementPerStrategy(soteriaCoverageProduct.address)).to.equal(mcrps.add(activeCoverLimit));
-    //     });
-    // });
+            expect (await soteriaCoverageProduct.rewardPointsOf(policyholder2.address)).eq(0)
+            expect (await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).eq(ONE_ETH)
+            expect (await soteriaCoverageProduct.accountBalanceOf(policyholder2.address)).eq(ONE_ETH)
+            expect (await soteriaCoverageProduct.policyStatus(POLICY_ID_2)).eq(true)
+            expect (await soteriaCoverageProduct.policyOf(policyholder2.address)).eq(POLICY_ID_2)
+            expect (await soteriaCoverageProduct.ownerOf(POLICY_ID_2)).eq(policyholder2.address)
+            expect (await soteriaCoverageProduct.activeCoverLimit()).eq(ONE_ETH.mul(2))
+            expect (await soteriaCoverageProduct.policyCount()).eq(2)
+            expect (await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2)).eq(ONE_ETH)
+            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(ONE_ETH.mul(2));
+        });
+        it("policy holder should have policy nft after buying coverage", async () => {
+            expect(await soteriaCoverageProduct.connect(policyholder1).balanceOf(policyholder1.address)).to.equal(1);
+            expect(await soteriaCoverageProduct.connect(policyholder2).balanceOf(policyholder2.address)).to.equal(1);
+        });
+        it("should update policy manager active cover amount", async () => {
+            let activeCoverLimit = await soteriaCoverageProduct.activeCoverLimit();
+            expect(await policyManager.connect(governor).activeCoverAmount()).to.equal(pmActiveCoverAmount.add(activeCoverLimit));
+            expect(await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(pmSoteriaActiveCoverAmount.add(activeCoverLimit));
+        });
+        it("should update risk manager mcr", async () => {
+            let activeCoverLimit = await soteriaCoverageProduct.connect(governor).activeCoverLimit();
+            expect(await riskManager.connect(governor).minCapitalRequirement()).to.equal(mcr.add(activeCoverLimit));
+            expect(await riskManager.connect(governor).minCapitalRequirementPerStrategy(soteriaCoverageProduct.address)).to.equal(mcrps.add(activeCoverLimit));
+        });
+    });
 
-    // describe("deposit", () => {
-    //     it("can deposit", async () => {
-    //         let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
-    //         let soteriaContractETHbalance = await provider.getBalance(soteriaCoverageProduct.address);
-    //         let tx = await soteriaCoverageProduct.connect(policyholder1).deposit(policyholder1.address, { value: ONE_ETH });
-    //         await expect(tx).emit(soteriaCoverageProduct, "DepositMade").withArgs(policyholder1.address, ONE_ETH);
-    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(accountBalance.add(ONE_ETH));
-    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaContractETHbalance.add(ONE_ETH));
-    //     });
+    describe("deposit", () => {
+        it("can deposit", async () => {
+            let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
+            let soteriaContractETHbalance = await provider.getBalance(soteriaCoverageProduct.address);
+            let tx = await soteriaCoverageProduct.connect(policyholder1).deposit(policyholder1.address, { value: ONE_ETH });
+            await expect(tx).emit(soteriaCoverageProduct, "DepositMade").withArgs(policyholder1.address, ONE_ETH);
+            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(accountBalance.add(ONE_ETH));
+            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaContractETHbalance.add(ONE_ETH));
+        });
 
-    //     it("can deposit on behalf of policy holder", async () => {
-    //         let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder2.address);
-    //         let soteriaContractETHbalance = await provider.getBalance(soteriaCoverageProduct.address);
-    //         let tx = await soteriaCoverageProduct.connect(policyholder1).deposit(policyholder2.address, { value: ONE_ETH });
-    //         await expect(tx).emit(soteriaCoverageProduct, "DepositMade").withArgs(policyholder2.address, ONE_ETH);
-    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder2.address)).to.equal(accountBalance.add(ONE_ETH));
-    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaContractETHbalance.add(ONE_ETH));
-    //     });
+        it("can deposit on behalf of policy holder", async () => {
+            let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder2.address);
+            let soteriaContractETHbalance = await provider.getBalance(soteriaCoverageProduct.address);
+            let tx = await soteriaCoverageProduct.connect(policyholder1).deposit(policyholder2.address, { value: ONE_ETH });
+            await expect(tx).emit(soteriaCoverageProduct, "DepositMade").withArgs(policyholder2.address, ONE_ETH);
+            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder2.address)).to.equal(accountBalance.add(ONE_ETH));
+            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaContractETHbalance.add(ONE_ETH));
+        });
 
-    //     it("can deposit via fallback", async () => {
-    //         let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder2.address);
-    //         let soteriaContractETHbalance = await provider.getBalance(soteriaCoverageProduct.address);
-    //         let tx = await policyholder1.sendTransaction({ to: soteriaCoverageProduct.address, value: ONE_ETH });
-    //         await expect(tx).emit(soteriaCoverageProduct, "DepositMade").withArgs(policyholder1.address, ONE_ETH);
-    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(accountBalance.add(ONE_ETH));
-    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaContractETHbalance.add(ONE_ETH));
-    //     });
+        it("can deposit via fallback", async () => {
+            let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder2.address);
+            let soteriaContractETHbalance = await provider.getBalance(soteriaCoverageProduct.address);
+            let tx = await policyholder1.sendTransaction({ to: soteriaCoverageProduct.address, value: ONE_ETH });
+            await expect(tx).emit(soteriaCoverageProduct, "DepositMade").withArgs(policyholder1.address, ONE_ETH);
+            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(accountBalance.add(ONE_ETH));
+            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaContractETHbalance.add(ONE_ETH));
+        });
 
-    //     it("can deposit via receive", async () => {
-    //         let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
-    //         let soteriaContractETHbalance = await provider.getBalance(soteriaCoverageProduct.address);
-    //         let tx = await policyholder1.sendTransaction({ to: soteriaCoverageProduct.address, value: ONE_ETH, data:"0x00"});
-    //         await expect(tx).emit(soteriaCoverageProduct, "DepositMade").withArgs(policyholder1.address, ONE_ETH);
-    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(accountBalance.add(ONE_ETH));
-    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaContractETHbalance.add(ONE_ETH));
-    //     });
+        it("can deposit via receive", async () => {
+            let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
+            let soteriaContractETHbalance = await provider.getBalance(soteriaCoverageProduct.address);
+            let tx = await policyholder1.sendTransaction({ to: soteriaCoverageProduct.address, value: ONE_ETH, data:"0x00"});
+            await expect(tx).emit(soteriaCoverageProduct, "DepositMade").withArgs(policyholder1.address, ONE_ETH);
+            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(accountBalance.add(ONE_ETH));
+            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaContractETHbalance.add(ONE_ETH));
+        });
 
-    //     it("cannot deposit while paused", async () => {
-    //         await soteriaCoverageProduct.connect(governor).setPaused(true);
-    //         await expect(soteriaCoverageProduct.connect(policyholder1).deposit(policyholder1.address, { value: ONE_ETH })).to.revertedWith("contract paused");
-    //         await soteriaCoverageProduct.connect(governor).setPaused(false);
-    //     });
-    // });
+        it("cannot deposit while paused", async () => {
+            await soteriaCoverageProduct.connect(governor).setPaused(true);
+            await expect(soteriaCoverageProduct.connect(policyholder1).deposit(policyholder1.address, { value: ONE_ETH })).to.revertedWith("contract paused");
+            await soteriaCoverageProduct.connect(governor).setPaused(false);
+        });
+    });
 
-    // describe("withdraw", () => {
-    //     let initialAccountBalance: BN;
-    //     let initialPolicyCover:BN;
+    describe("withdraw", () => {
+        let initialAccountBalance: BN;
+        let initialPolicyCover:BN;
 
-    //     before(async () => {
-    //         initialAccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
-    //         initialPolicyCover = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1);
-    //     })
+        before(async () => {
+            initialAccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
+            initialPolicyCover = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1);
+        })
         
-    //     it("cannot withdraw while paused", async () => {
-    //         await soteriaCoverageProduct.connect(governor).setPaused(true);
-    //         await expect(soteriaCoverageProduct.connect(policyholder1).withdraw(ONE_ETH)).to.revertedWith("contract paused");
-    //         await soteriaCoverageProduct.connect(governor).setPaused(false);
-    //     });
-    //     it("cannot withdraw more than account balance", async () => {
-    //         let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
-    //         await expect(soteriaCoverageProduct.connect(policyholder1).withdraw(accountBalance.add(1))).to.revertedWith("cannot withdraw this amount");
-    //     })
-    //     it("can withdraw", async () => {
-    //         let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
-    //         let policyholderETHBalance = await provider.getBalance(policyholder1.address)
-    //         let soteriaETHBalance = await provider.getBalance(soteriaCoverageProduct.address)
+        it("cannot withdraw while paused", async () => {
+            await soteriaCoverageProduct.connect(governor).setPaused(true);
+            await expect(soteriaCoverageProduct.connect(policyholder1).withdraw(ONE_ETH)).to.revertedWith("contract paused");
+            await soteriaCoverageProduct.connect(governor).setPaused(false);
+        });
+        it("cannot withdraw more than account balance", async () => {
+            let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
+            await expect(soteriaCoverageProduct.connect(policyholder1).withdraw(accountBalance.add(1))).to.revertedWith("cannot withdraw this amount");
+        })
+        it("can withdraw", async () => {
+            let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
+            let policyholderETHBalance = await provider.getBalance(policyholder1.address)
+            let soteriaETHBalance = await provider.getBalance(soteriaCoverageProduct.address)
             
-    //         let tx = await soteriaCoverageProduct.connect(policyholder1).withdraw(ONE_ETH);
+            let tx = await soteriaCoverageProduct.connect(policyholder1).withdraw(ONE_ETH);
             
-    //         let receipt = await tx.wait();
-    //         let gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice);
-    //         await expect(tx).emit(soteriaCoverageProduct, "WithdrawMade").withArgs(policyholder1.address, ONE_ETH);
-    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(accountBalance.sub(ONE_ETH));
-    //         expect(await provider.getBalance(policyholder1.address)).eq(policyholderETHBalance.add(ONE_ETH).sub(gasCost))
-    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).eq(soteriaETHBalance.sub(ONE_ETH))
-    //     })
-    //     it("will deactivate policy if withdraw below minimum permitted account balance", async () => {
-    //         let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
-    //         let policyholderETHBalance = await provider.getBalance(policyholder1.address)
-    //         let soteriaETHBalance = await provider.getBalance(soteriaCoverageProduct.address)
-    //         let policyCoverLimit = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1);
-    //         let activeCoverLimit = await soteriaCoverageProduct.activeCoverLimit();
+            let receipt = await tx.wait();
+            let gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice);
+            await expect(tx).emit(soteriaCoverageProduct, "WithdrawMade").withArgs(policyholder1.address, ONE_ETH);
+            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(accountBalance.sub(ONE_ETH));
+            expect(await provider.getBalance(policyholder1.address)).eq(policyholderETHBalance.add(ONE_ETH).sub(gasCost))
+            expect(await provider.getBalance(soteriaCoverageProduct.address)).eq(soteriaETHBalance.sub(ONE_ETH))
+        })
+        it("will deactivate policy if withdraw below minimum permitted account balance", async () => {
+            let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
+            let policyholderETHBalance = await provider.getBalance(policyholder1.address)
+            let soteriaETHBalance = await provider.getBalance(soteriaCoverageProduct.address)
+            let policyCoverLimit = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1);
+            let activeCoverLimit = await soteriaCoverageProduct.activeCoverLimit();
 
-    //         let tx = await soteriaCoverageProduct.connect(policyholder1).withdraw(accountBalance.sub(1));
+            let tx = await soteriaCoverageProduct.connect(policyholder1).withdraw(accountBalance.sub(1));
 
-    //         let receipt = await tx.wait();
-    //         let gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice);
-    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyDeactivated").withArgs(POLICY_ID_1);
-    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(activeCoverLimit.sub(policyCoverLimit));
-    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(0);
-    //         expect(await provider.getBalance(policyholder1.address)).eq(policyholderETHBalance.add(accountBalance).sub(gasCost))
-    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).eq(soteriaETHBalance.sub(accountBalance))
-    //         expect (await soteriaCoverageProduct.policyStatus(POLICY_ID_1)).eq(false)
-    //         expect (await soteriaCoverageProduct.ownerOf(POLICY_ID_1)).eq(policyholder1.address)
-    //         expect (await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1)).eq(0)
-    //         expect (await soteriaCoverageProduct.activeCoverLimit()).eq(activeCoverLimit.sub(policyCoverLimit))
-    //         expect (await soteriaCoverageProduct.policyCount()).eq(2)
-    //     })
-    //     after(async () => {
-    //         let tx = await soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, initialPolicyCover, {value: initialPolicyCover})
-    //         let tx2 = await policyholder1.sendTransaction({ to: soteriaCoverageProduct.address, value: initialAccountBalance.sub(initialPolicyCover)});
-    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).eq(initialAccountBalance);
-    //         expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1)).eq(initialPolicyCover)
-    //         expect (await soteriaCoverageProduct.policyStatus(POLICY_ID_1)).eq(true)
-    //     })
-    // });
+            let receipt = await tx.wait();
+            let gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice);
+            await expect(tx).emit(soteriaCoverageProduct, "PolicyDeactivated").withArgs(POLICY_ID_1);
+            await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(activeCoverLimit.sub(policyCoverLimit));
+            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(0);
+            expect(await provider.getBalance(policyholder1.address)).eq(policyholderETHBalance.add(accountBalance).sub(gasCost))
+            expect(await provider.getBalance(soteriaCoverageProduct.address)).eq(soteriaETHBalance.sub(accountBalance))
+            expect (await soteriaCoverageProduct.policyStatus(POLICY_ID_1)).eq(false)
+            expect (await soteriaCoverageProduct.ownerOf(POLICY_ID_1)).eq(policyholder1.address)
+            expect (await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1)).eq(0)
+            expect (await soteriaCoverageProduct.activeCoverLimit()).eq(activeCoverLimit.sub(policyCoverLimit))
+            expect (await soteriaCoverageProduct.policyCount()).eq(2)
+        })
+        after(async () => {
+            let tx = await soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, initialPolicyCover, {value: initialPolicyCover})
+            let tx2 = await policyholder1.sendTransaction({ to: soteriaCoverageProduct.address, value: initialAccountBalance.sub(initialPolicyCover)});
+            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).eq(initialAccountBalance);
+            expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1)).eq(initialPolicyCover)
+            expect (await soteriaCoverageProduct.policyStatus(POLICY_ID_1)).eq(true)
+        })
+    });
 
-    // describe("updateCoverAmount", () => {
-    //     let maxCover: BN;
-    //     let maxCoverPerStrategy: BN;
-    //     let initialMCRForSoteria: BN;
-    //     let initialMCR: BN; // min. capital requirement
-    //     let initialSoteriaActiveCoverLimit: BN;
-    //     let initialPolicyCoverLimit: BN;
-    //     let initialPMActiveCoverLimit: BN; // policy manager active cover amount
-    //     let initialPMActiveCoverLimitForSoteria: BN; // policy manager active cover amount for soteria
+    describe("updateCoverAmount", () => {
+        let maxCover: BN;
+        let maxCoverPerStrategy: BN;
+        let initialMCRForSoteria: BN;
+        let initialMCR: BN; // min. capital requirement
+        let initialSoteriaActiveCoverLimit: BN;
+        let initialPolicyCoverLimit: BN;
+        let initialPMActiveCoverLimit: BN; // policy manager active cover amount
+        let initialPMActiveCoverLimitForSoteria: BN; // policy manager active cover amount for soteria
 
-    //     before(async () => {
-    //         maxCover = await riskManager.connect(governor).maxCover();
-    //         maxCoverPerStrategy = await riskManager.connect(governor).maxCoverPerStrategy(soteriaCoverageProduct.address);
+        before(async () => {
+            maxCover = await riskManager.connect(governor).maxCover();
+            maxCoverPerStrategy = await riskManager.connect(governor).maxCoverPerStrategy(soteriaCoverageProduct.address);
 
-    //         // risk manager current values
-    //         initialMCR = await riskManager.connect(governor).minCapitalRequirement();
-    //         initialMCRForSoteria = await riskManager.connect(governor).minCapitalRequirementPerStrategy(soteriaCoverageProduct.address);
+            // risk manager current values
+            initialMCR = await riskManager.connect(governor).minCapitalRequirement();
+            initialMCRForSoteria = await riskManager.connect(governor).minCapitalRequirementPerStrategy(soteriaCoverageProduct.address);
             
-    //         // policy manager current values
-    //         initialPMActiveCoverLimit = await policyManager.connect(governor).activeCoverAmount();
-    //         initialPMActiveCoverLimitForSoteria = await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
+            // policy manager current values
+            initialPMActiveCoverLimit = await policyManager.connect(governor).activeCoverAmount();
+            initialPMActiveCoverLimitForSoteria = await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
 
-    //         initialSoteriaActiveCoverLimit = await soteriaCoverageProduct.connect(policyholder1).activeCoverLimit();
-    //         initialPolicyCoverLimit = await soteriaCoverageProduct.connect(policyholder1).coverLimitOf(POLICY_ID_1);
+            initialSoteriaActiveCoverLimit = await soteriaCoverageProduct.connect(policyholder1).activeCoverLimit();
+            initialPolicyCoverLimit = await soteriaCoverageProduct.connect(policyholder1).coverLimitOf(POLICY_ID_1);
 
-    //         expect(await soteriaCoverageProduct.connect(policyholder1).ownerOf(POLICY_ID_1)).to.equal(policyholder1.address);
-    //     });
+            expect(await soteriaCoverageProduct.connect(policyholder1).ownerOf(POLICY_ID_1)).to.equal(policyholder1.address);
+        });
 
-    //     it("cannot update for zero cover amount", async () => {
-    //         await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, ZERO_AMOUNT)).to.revertedWith("zero cover value");
-    //     });
+        it("cannot update for zero cover amount", async () => {
+            await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, ZERO_AMOUNT)).to.revertedWith("zero cover value");
+        });
 
-    //     it("cannot update for invalid policy", async () => {
-    //         await expect(soteriaCoverageProduct.connect(governor).updateCoverLimit(POLICY_ID_3, NEW_COVER_LIMIT)).to.revertedWith("invalid policy");
-    //     });
+        it("cannot update for invalid policy", async () => {
+            await expect(soteriaCoverageProduct.connect(governor).updateCoverLimit(POLICY_ID_3, NEW_COVER_LIMIT)).to.revertedWith("invalid policy");
+        });
 
-    //     it("cannot update while paused", async () => {
-    //         await soteriaCoverageProduct.connect(governor).setPaused(true);
-    //         await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, NEW_COVER_LIMIT)).to.revertedWith("contract paused");
-    //         await soteriaCoverageProduct.connect(governor).setPaused(false);
-    //     });
+        it("cannot update while paused", async () => {
+            await soteriaCoverageProduct.connect(governor).setPaused(true);
+            await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, NEW_COVER_LIMIT)).to.revertedWith("contract paused");
+            await soteriaCoverageProduct.connect(governor).setPaused(false);
+        });
 
-    //     it("cannot update if non-governance or not own policy", async () => {
-    //         await expect(soteriaCoverageProduct.connect(deployer).updateCoverLimit(POLICY_ID_1, NEW_COVER_LIMIT)).to.revertedWith("not owner or governance");
-    //     })
+        it("cannot update if non-governance or not own policy", async () => {
+            await expect(soteriaCoverageProduct.connect(deployer).updateCoverLimit(POLICY_ID_1, NEW_COVER_LIMIT)).to.revertedWith("not owner or governance");
+        })
 
-    //     it("cannot update if max cover is exceeded", async () => {
-    //         await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, maxCover.add(1))).to.revertedWith("insufficient capacity for new cover");
-    //     });
+        it("cannot update if max cover is exceeded", async () => {
+            await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, maxCover.add(1))).to.revertedWith("insufficient capacity for new cover");
+        });
 
-    //     it("cannot update if max cover for the strategy is exceeded", async () => {
-    //         await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, maxCoverPerStrategy.add(1))).to.revertedWith("insufficient capacity for new cover");
-    //     });
+        it("cannot update if max cover for the strategy is exceeded", async () => {
+            await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, maxCoverPerStrategy.add(1))).to.revertedWith("insufficient capacity for new cover");
+        });
 
-    //     it("cannot update if below minimum required account balance for newCoverLimit", async () => {
-    //         let maxRateNum = await soteriaCoverageProduct.maxRateNum();
-    //         let maxRateDenom = await soteriaCoverageProduct.maxRateDenom();
-    //         let chargeCycle = await soteriaCoverageProduct.chargeCycle();
-    //         let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)
-    //         let maxPermissibleNewCoverLimit = accountBalance.mul(maxRateDenom).div(maxRateNum).div(chargeCycle)
-    //         await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, maxPermissibleNewCoverLimit.add(ONE_ETH))).to.revertedWith("insufficient deposit for minimum required account balance");
-    //     })
+        it("cannot update if below minimum required account balance for newCoverLimit", async () => {
+            let maxRateNum = await soteriaCoverageProduct.maxRateNum();
+            let maxRateDenom = await soteriaCoverageProduct.maxRateDenom();
+            let chargeCycle = await soteriaCoverageProduct.chargeCycle();
+            let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)
+            let maxPermissibleNewCoverLimit = accountBalance.mul(maxRateDenom).div(maxRateNum).div(chargeCycle)
+            await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, maxPermissibleNewCoverLimit.add(ONE_ETH))).to.revertedWith("insufficient deposit for minimum required account balance");
+        })
 
-    //     it("policy owner can update policy", async () => {
-    //         let activeCoverLimit = initialSoteriaActiveCoverLimit.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
+        it("policy owner can update policy", async () => {
+            let activeCoverLimit = initialSoteriaActiveCoverLimit.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
             
-    //         let tx = await soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, NEW_COVER_LIMIT);
+            let tx = await soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, NEW_COVER_LIMIT);
 
-    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyUpdated").withArgs(POLICY_ID_1);
-    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(activeCoverLimit);
-    //         expect(await soteriaCoverageProduct.connect(policyholder1).activeCoverLimit()).to.equal(activeCoverLimit);
-    //         expect(await soteriaCoverageProduct.connect(policyholder1).coverLimitOf(POLICY_ID_1)).to.equal(NEW_COVER_LIMIT);
-    //     });
+            await expect(tx).emit(soteriaCoverageProduct, "PolicyUpdated").withArgs(POLICY_ID_1);
+            await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(activeCoverLimit);
+            expect(await soteriaCoverageProduct.connect(policyholder1).activeCoverLimit()).to.equal(activeCoverLimit);
+            expect(await soteriaCoverageProduct.connect(policyholder1).coverLimitOf(POLICY_ID_1)).to.equal(NEW_COVER_LIMIT);
+        });
 
-    //     it("governor can update policy", async () => {
-    //         let TEST_COVER_LIMIT = NEW_COVER_LIMIT.add(ONE_ETH)
-    //         let activeCoverLimit = initialSoteriaActiveCoverLimit.add(TEST_COVER_LIMIT).sub(initialPolicyCoverLimit);
+        it("governor can update policy", async () => {
+            let TEST_COVER_LIMIT = NEW_COVER_LIMIT.add(ONE_ETH)
+            let activeCoverLimit = initialSoteriaActiveCoverLimit.add(TEST_COVER_LIMIT).sub(initialPolicyCoverLimit);
 
-    //         let tx = await soteriaCoverageProduct.connect(governor).updateCoverLimit(POLICY_ID_1, TEST_COVER_LIMIT);
+            let tx = await soteriaCoverageProduct.connect(governor).updateCoverLimit(POLICY_ID_1, TEST_COVER_LIMIT);
 
-    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyUpdated").withArgs(POLICY_ID_1);
-    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(activeCoverLimit);
-    //         expect(await soteriaCoverageProduct.connect(policyholder1).activeCoverLimit()).to.equal(activeCoverLimit);
-    //         expect(await soteriaCoverageProduct.connect(policyholder1).coverLimitOf(POLICY_ID_1)).to.equal(TEST_COVER_LIMIT);
+            await expect(tx).emit(soteriaCoverageProduct, "PolicyUpdated").withArgs(POLICY_ID_1);
+            await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(activeCoverLimit);
+            expect(await soteriaCoverageProduct.connect(policyholder1).activeCoverLimit()).to.equal(activeCoverLimit);
+            expect(await soteriaCoverageProduct.connect(policyholder1).coverLimitOf(POLICY_ID_1)).to.equal(TEST_COVER_LIMIT);
 
-    //         // Revert changes
-    //         await soteriaCoverageProduct.connect(governor).updateCoverLimit(POLICY_ID_1, NEW_COVER_LIMIT);
-    //     });
+            // Revert changes
+            await soteriaCoverageProduct.connect(governor).updateCoverLimit(POLICY_ID_1, NEW_COVER_LIMIT);
+        });
 
-    //     it("should update policy manager active cover limit", async () => {
-    //         let amount1 = initialPMActiveCoverLimit.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
-    //         let amount2 = initialPMActiveCoverLimitForSoteria.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
+        it("should update policy manager active cover limit", async () => {
+            let amount1 = initialPMActiveCoverLimit.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
+            let amount2 = initialPMActiveCoverLimitForSoteria.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
 
-    //         expect(await policyManager.connect(governor).activeCoverAmount()).to.equal(amount1);
-    //         expect(await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(amount2);
-    //     });
+            expect(await policyManager.connect(governor).activeCoverAmount()).to.equal(amount1);
+            expect(await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(amount2);
+        });
 
-    //     it("should update risk manager mcr", async () => {         
-    //         let amount1 = initialMCR.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
-    //         let amount2 = initialMCRForSoteria.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
-    //         expect(await riskManager.connect(governor).minCapitalRequirement()).to.equal(amount1);
-    //         expect(await riskManager.connect(governor).minCapitalRequirementPerStrategy(soteriaCoverageProduct.address)).to.equal(amount2);
-    //     });
-    // });
+        it("should update risk manager mcr", async () => {         
+            let amount1 = initialMCR.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
+            let amount2 = initialMCRForSoteria.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
+            expect(await riskManager.connect(governor).minCapitalRequirement()).to.equal(amount1);
+            expect(await riskManager.connect(governor).minCapitalRequirementPerStrategy(soteriaCoverageProduct.address)).to.equal(amount2);
+        });
+    });
 
-    // describe("deactivatePolicy", () => {
-    //     before(async () => {
-    //         let tx = await soteriaCoverageProduct.connect(policyholder3).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, {value: ONE_ETH});
-    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyCreated").withArgs(POLICY_ID_3);
-    //     });
+    describe("deactivatePolicy", () => {
+        before(async () => {
+            let tx = await soteriaCoverageProduct.connect(policyholder3).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, {value: ONE_ETH});
+            await expect(tx).emit(soteriaCoverageProduct, "PolicyCreated").withArgs(POLICY_ID_3);
+        });
 
-    //     it("cannot deactivate an invalid policy", async () => {
-    //         await expect(soteriaCoverageProduct.connect(policyholder3).deactivatePolicy(INVALID_POLICY_ID)).to.revertedWith("invalid policy");
-    //     });
+        it("cannot deactivate an invalid policy", async () => {
+            await expect(soteriaCoverageProduct.connect(policyholder3).deactivatePolicy(INVALID_POLICY_ID)).to.revertedWith("invalid policy");
+        });
 
-    //     it("cannot deactivate someone else's policy", async () => {
-    //         await expect(soteriaCoverageProduct.connect(policyholder3).deactivatePolicy(POLICY_ID_1)).to.revertedWith("not owner or governance");
-    //     });
+        it("cannot deactivate someone else's policy", async () => {
+            await expect(soteriaCoverageProduct.connect(policyholder3).deactivatePolicy(POLICY_ID_1)).to.revertedWith("not owner or governance");
+        });
 
-    //     it("policy owner can deactivate policy", async () => {
-    //         let initialPolicyholderETHBalance = await policyholder3.getBalance();
-    //         let initialPolicyholderAccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)
-    //         let initialPolicyCoverLimit = await soteriaCoverageProduct.connect(policyholder3).coverLimitOf(POLICY_ID_3);
-    //         let initialActiveCoverLimit = await soteriaCoverageProduct.connect(policyholder3).activeCoverLimit();
-    //         let initialAvailableCoverCapacity = await soteriaCoverageProduct.availableCoverCapacity();
-    //         let initialPMActiveCoverAmount = await policyManager.connect(policyholder3).activeCoverAmount();
-    //         let initialPMActiveCoverAmountForSoteria = await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
+        it("policy owner can deactivate policy", async () => {
+            let initialPolicyholderETHBalance = await policyholder3.getBalance();
+            let initialPolicyholderAccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)
+            let initialPolicyCoverLimit = await soteriaCoverageProduct.connect(policyholder3).coverLimitOf(POLICY_ID_3);
+            let initialActiveCoverLimit = await soteriaCoverageProduct.connect(policyholder3).activeCoverLimit();
+            let initialAvailableCoverCapacity = await soteriaCoverageProduct.availableCoverCapacity();
+            let initialPMActiveCoverAmount = await policyManager.connect(policyholder3).activeCoverAmount();
+            let initialPMActiveCoverAmountForSoteria = await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
 
-    //         // deactivate policy
-    //         let tx = await soteriaCoverageProduct.connect(policyholder3).deactivatePolicy(POLICY_ID_3);
-    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyDeactivated").withArgs(POLICY_ID_3);
-    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
+            // deactivate policy
+            let tx = await soteriaCoverageProduct.connect(policyholder3).deactivatePolicy(POLICY_ID_3);
+            await expect(tx).emit(soteriaCoverageProduct, "PolicyDeactivated").withArgs(POLICY_ID_3);
+            await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
 
-    //         // user should get refunds
-    //         let receipt = await tx.wait();
-    //         let gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice);
-    //         expect(await policyholder3.getBalance()).eq(initialPolicyholderETHBalance.add(initialPolicyholderAccountBalance).sub(gasCost))
-    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).to.equal(ZERO_AMOUNT);
+            // user should get refunds
+            let receipt = await tx.wait();
+            let gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice);
+            expect(await policyholder3.getBalance()).eq(initialPolicyholderETHBalance.add(initialPolicyholderAccountBalance).sub(gasCost))
+            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).to.equal(ZERO_AMOUNT);
 
-    //         // soteria active cover amount should be decreased
-    //         expect(await soteriaCoverageProduct.activeCoverLimit()).to.equal(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
+            // soteria active cover amount should be decreased
+            expect(await soteriaCoverageProduct.activeCoverLimit()).to.equal(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
 
-    //         // cover limit should be zero
-    //         expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_3)).to.equal(ZERO_AMOUNT);
-    //         expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity.add(initialPolicyCoverLimit))
+            // cover limit should be zero
+            expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_3)).to.equal(ZERO_AMOUNT);
+            expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity.add(initialPolicyCoverLimit))
 
-    //         // policy status should be inactive
-    //         expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_3)).to.be.false;
-    //         expect(await soteriaCoverageProduct.policyCount()).eq(3)
+            // policy status should be inactive
+            expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_3)).to.be.false;
+            expect(await soteriaCoverageProduct.policyCount()).eq(3)
 
-    //         // policy manager active cover amount and active cover amount for soteria should be decreased
-    //         expect(await policyManager.connect(policyholder3).activeCoverAmount()).to.equal(initialPMActiveCoverAmount.sub(initialPolicyCoverLimit));
-    //         expect(await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(initialPMActiveCoverAmountForSoteria.sub(initialPolicyCoverLimit));
+            // policy manager active cover amount and active cover amount for soteria should be decreased
+            expect(await policyManager.connect(policyholder3).activeCoverAmount()).to.equal(initialPMActiveCoverAmount.sub(initialPolicyCoverLimit));
+            expect(await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(initialPMActiveCoverAmountForSoteria.sub(initialPolicyCoverLimit));
 
-    //         // revert for next unit test - governor can deactivate policy
-    //         await policyholder3.sendTransaction({ to: soteriaCoverageProduct.address, value: initialPolicyholderAccountBalance });
-    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).eq(initialPolicyholderAccountBalance)
-    //         await soteriaCoverageProduct.connect(policyholder3).activatePolicy(policyholder3.address, initialPolicyCoverLimit)
-    //         expect(await soteriaCoverageProduct.connect(policyholder3).coverLimitOf(POLICY_ID_3)).eq(initialPolicyCoverLimit)
-    //         expect(await soteriaCoverageProduct.connect(policyholder3).activeCoverLimit()).eq(initialActiveCoverLimit)
-    //         expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity)
-    //         expect(await policyManager.connect(policyholder3).activeCoverAmount()).eq(initialPMActiveCoverAmount)
-    //         expect(await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).eq(initialPMActiveCoverAmountForSoteria)
-    //     });
+            // revert for next unit test - governor can deactivate policy
+            await policyholder3.sendTransaction({ to: soteriaCoverageProduct.address, value: initialPolicyholderAccountBalance });
+            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).eq(initialPolicyholderAccountBalance)
+            await soteriaCoverageProduct.connect(policyholder3).activatePolicy(policyholder3.address, initialPolicyCoverLimit)
+            expect(await soteriaCoverageProduct.connect(policyholder3).coverLimitOf(POLICY_ID_3)).eq(initialPolicyCoverLimit)
+            expect(await soteriaCoverageProduct.connect(policyholder3).activeCoverLimit()).eq(initialActiveCoverLimit)
+            expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity)
+            expect(await policyManager.connect(policyholder3).activeCoverAmount()).eq(initialPMActiveCoverAmount)
+            expect(await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).eq(initialPMActiveCoverAmountForSoteria)
+        });
 
-    //     it("governor can deactivate policy", async () => {
-    //         let initialPolicyholderETHBalance = await policyholder3.getBalance();
-    //         let initialPolicyholderAccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)
-    //         let initialPolicyCoverLimit = await soteriaCoverageProduct.connect(policyholder3).coverLimitOf(POLICY_ID_3);
-    //         let initialActiveCoverLimit = await soteriaCoverageProduct.connect(policyholder3).activeCoverLimit();
-    //         let initialAvailableCoverCapacity = await soteriaCoverageProduct.availableCoverCapacity();
-    //         let initialPMActiveCoverAmount = await policyManager.connect(policyholder3).activeCoverAmount();
-    //         let initialPMActiveCoverAmountForSoteria = await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
+        it("governor can deactivate policy", async () => {
+            let initialPolicyholderETHBalance = await policyholder3.getBalance();
+            let initialPolicyholderAccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)
+            let initialPolicyCoverLimit = await soteriaCoverageProduct.connect(policyholder3).coverLimitOf(POLICY_ID_3);
+            let initialActiveCoverLimit = await soteriaCoverageProduct.connect(policyholder3).activeCoverLimit();
+            let initialAvailableCoverCapacity = await soteriaCoverageProduct.availableCoverCapacity();
+            let initialPMActiveCoverAmount = await policyManager.connect(policyholder3).activeCoverAmount();
+            let initialPMActiveCoverAmountForSoteria = await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
 
-    //         // deactivate policy
-    //         let tx = await soteriaCoverageProduct.connect(governor).deactivatePolicy(POLICY_ID_3);
-    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyDeactivated").withArgs(POLICY_ID_3);
-    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
+            // deactivate policy
+            let tx = await soteriaCoverageProduct.connect(governor).deactivatePolicy(POLICY_ID_3);
+            await expect(tx).emit(soteriaCoverageProduct, "PolicyDeactivated").withArgs(POLICY_ID_3);
+            await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
 
-    //         // user should get refunds
-    //         let receipt = await tx.wait();
-    //         let gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice);
-    //         expect(await policyholder3.getBalance()).eq(initialPolicyholderETHBalance.add(initialPolicyholderAccountBalance))
-    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).to.equal(ZERO_AMOUNT);
+            // user should get refunds
+            let receipt = await tx.wait();
+            let gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice);
+            expect(await policyholder3.getBalance()).eq(initialPolicyholderETHBalance.add(initialPolicyholderAccountBalance))
+            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).to.equal(ZERO_AMOUNT);
 
-    //         // soteria active cover amount should be decreased
-    //         expect(await soteriaCoverageProduct.activeCoverLimit()).to.equal(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
+            // soteria active cover amount should be decreased
+            expect(await soteriaCoverageProduct.activeCoverLimit()).to.equal(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
 
-    //         // cover limit should be zero
-    //         expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_3)).to.equal(ZERO_AMOUNT);
-    //         expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity.add(initialPolicyCoverLimit))
+            // cover limit should be zero
+            expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_3)).to.equal(ZERO_AMOUNT);
+            expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity.add(initialPolicyCoverLimit))
 
-    //         // policy status should be inactive
-    //         expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_3)).to.be.false;
-    //         expect(await soteriaCoverageProduct.policyCount()).eq(3)
+            // policy status should be inactive
+            expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_3)).to.be.false;
+            expect(await soteriaCoverageProduct.policyCount()).eq(3)
 
-    //         // policy manager active cover amount and active cover amount for soteria should be decreased
-    //         expect(await policyManager.connect(policyholder3).activeCoverAmount()).to.equal(initialPMActiveCoverAmount.sub(initialPolicyCoverLimit));
-    //         expect(await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(initialPMActiveCoverAmountForSoteria.sub(initialPolicyCoverLimit));
+            // policy manager active cover amount and active cover amount for soteria should be decreased
+            expect(await policyManager.connect(policyholder3).activeCoverAmount()).to.equal(initialPMActiveCoverAmount.sub(initialPolicyCoverLimit));
+            expect(await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(initialPMActiveCoverAmountForSoteria.sub(initialPolicyCoverLimit));
 
-    //         // revert for next unit test - governor can deactivate policy
-    //         await soteriaCoverageProduct.connect(governor).deposit(policyholder3.address, {value: initialPolicyholderAccountBalance})
-    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).eq(initialPolicyholderAccountBalance)
-    //         await soteriaCoverageProduct.connect(governor).activatePolicy(policyholder3.address, initialPolicyCoverLimit)
-    //         expect(await soteriaCoverageProduct.connect(policyholder3).coverLimitOf(POLICY_ID_3)).eq(initialPolicyCoverLimit)
-    //         expect(await soteriaCoverageProduct.connect(policyholder3).activeCoverLimit()).eq(initialActiveCoverLimit)
-    //         expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity)
-    //         expect(await policyManager.connect(policyholder3).activeCoverAmount()).eq(initialPMActiveCoverAmount)
-    //         expect(await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).eq(initialPMActiveCoverAmountForSoteria)
-    //     });
-    // });
+            // revert for next unit test - governor can deactivate policy
+            await soteriaCoverageProduct.connect(governor).deposit(policyholder3.address, {value: initialPolicyholderAccountBalance})
+            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).eq(initialPolicyholderAccountBalance)
+            await soteriaCoverageProduct.connect(governor).activatePolicy(policyholder3.address, initialPolicyCoverLimit)
+            expect(await soteriaCoverageProduct.connect(policyholder3).coverLimitOf(POLICY_ID_3)).eq(initialPolicyCoverLimit)
+            expect(await soteriaCoverageProduct.connect(policyholder3).activeCoverLimit()).eq(initialActiveCoverLimit)
+            expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity)
+            expect(await policyManager.connect(policyholder3).activeCoverAmount()).eq(initialPMActiveCoverAmount)
+            expect(await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).eq(initialPMActiveCoverAmountForSoteria)
+        });
+    });
 
-    // describe("chargePremiums", () => {
-    //     it("cannot charge premiums by non-governance", async () => {
-    //         await expect(soteriaCoverageProduct.connect(policyholder1).chargePremiums([policyholder1.address, policyholder2.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM])).to.revertedWith("!governance");
-    //     });
+    describe("chargePremiums", () => {
+        it("cannot charge premiums by non-governance", async () => {
+            await expect(soteriaCoverageProduct.connect(policyholder1).chargePremiums([policyholder1.address, policyholder2.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM])).to.revertedWith("!governance");
+        });
 
-    //     it("cannot charge premiums if argument lenghts are mismatched", async () => {
-    //         await expect(soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address, policyholder3.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM])).to.revertedWith("length mismatch");
-    //     });
+        it("cannot charge premiums if argument lenghts are mismatched", async () => {
+            await expect(soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address, policyholder3.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM])).to.revertedWith("length mismatch");
+        });
 
-    //     it("cannot charge premiums if policy count is exceeded", async () => {
-    //         await expect(soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address, policyholder3.address, policyholder4.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM])).to.revertedWith("policy count exceeded");
-    //     });
+        it("cannot charge premiums if policy count is exceeded", async () => {
+            await expect(soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address, policyholder3.address, policyholder4.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM])).to.revertedWith("policy count exceeded");
+        });
 
-    //     it("cannot charge more than max rate", async () => {
-    //         await expect(soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address], [WEEKLY_MAX_PREMIUM.mul(11).div(10), WEEKLY_MAX_PREMIUM.mul(11).div(10)])).to.revertedWith("charging more than promised maximum rate");
-    //     })
+        it("cannot charge more than max rate", async () => {
+            await expect(soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address], [WEEKLY_MAX_PREMIUM.mul(11).div(10), WEEKLY_MAX_PREMIUM.mul(11).div(10)])).to.revertedWith("charging more than promised maximum rate");
+        })
 
-    //     it("can charge premiums", async () => {
-    //         // CASE 1 - Charge weekly premium for two policyholders, no reward points involved
+        it("can charge premiums", async () => {
+            // CASE 1 - Charge weekly premium for two policyholders, no reward points involved
             
-    //         // premiums are routed to the vault in treasury!
-    //         let soteriaBalance = await provider.getBalance(soteriaCoverageProduct.address);
-    //         let vaultBalance = await provider.getBalance(vault.address);
-    //         let policyholder1AccountBalance = await soteriaCoverageProduct.connect(policyholder1).accountBalanceOf(policyholder1.address);
-    //         let policyholder2AccountBalance = await soteriaCoverageProduct.connect(policyholder1).accountBalanceOf(policyholder2.address);
-    //         let initialCoverLimit1 = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1);
-    //         let initialCoverLimit2 = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2);
-    //         let initialActiveCoverLimit = await soteriaCoverageProduct.activeCoverLimit();
-    //         let initialActiveCoverCapacity = await soteriaCoverageProduct.availableCoverCapacity();
+            // premiums are routed to the vault in treasury!
+            let soteriaBalance = await provider.getBalance(soteriaCoverageProduct.address);
+            let vaultBalance = await provider.getBalance(vault.address);
+            let policyholder1AccountBalance = await soteriaCoverageProduct.connect(policyholder1).accountBalanceOf(policyholder1.address);
+            let policyholder2AccountBalance = await soteriaCoverageProduct.connect(policyholder1).accountBalanceOf(policyholder2.address);
+            let initialCoverLimit1 = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1);
+            let initialCoverLimit2 = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2);
+            let initialActiveCoverLimit = await soteriaCoverageProduct.activeCoverLimit();
+            let initialActiveCoverCapacity = await soteriaCoverageProduct.availableCoverCapacity();
 
-    //         // charge premiums
-    //         let tx = soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM]);
-    //         await expect(tx).emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder1.address, WEEKLY_MAX_PREMIUM);
-    //         await expect(tx).emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder2.address, WEEKLY_MAX_PREMIUM);
+            // charge premiums
+            let tx = soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM]);
+            await expect(tx).emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder1.address, WEEKLY_MAX_PREMIUM);
+            await expect(tx).emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder2.address, WEEKLY_MAX_PREMIUM);
          
-    //         // Soteria account balance should be decreased
-    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(policyholder1AccountBalance.sub(WEEKLY_MAX_PREMIUM));
-    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder2.address)).to.equal(policyholder2AccountBalance.sub(WEEKLY_MAX_PREMIUM));
+            // Soteria account balance should be decreased
+            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(policyholder1AccountBalance.sub(WEEKLY_MAX_PREMIUM));
+            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder2.address)).to.equal(policyholder2AccountBalance.sub(WEEKLY_MAX_PREMIUM));
 
-    //         // soteria balance should be decreased
-    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaBalance.sub(WEEKLY_MAX_PREMIUM.mul(2)));
+            // soteria balance should be decreased
+            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaBalance.sub(WEEKLY_MAX_PREMIUM.mul(2)));
 
-    //         // premium should be sent to treasury
-    //         expect(await provider.getBalance(vault.address)).to.equal(vaultBalance.add(WEEKLY_MAX_PREMIUM.mul(2)));
-    //         expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialActiveCoverCapacity.add(WEEKLY_MAX_PREMIUM.mul(2)))
+            // premium should be sent to treasury
+            expect(await provider.getBalance(vault.address)).to.equal(vaultBalance.add(WEEKLY_MAX_PREMIUM.mul(2)));
+            expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialActiveCoverCapacity.add(WEEKLY_MAX_PREMIUM.mul(2)))
 
-    //         // following mappings should be unchanged
-    //         expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1)).eq(initialCoverLimit1)
-    //         expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2)).eq(initialCoverLimit2)
-    //         expect(await soteriaCoverageProduct.activeCoverLimit()).eq(initialActiveCoverLimit)
-    //     });
+            // following mappings should be unchanged
+            expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1)).eq(initialCoverLimit1)
+            expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2)).eq(initialCoverLimit2)
+            expect(await soteriaCoverageProduct.activeCoverLimit()).eq(initialActiveCoverLimit)
+        });
 
-    //     it("can partially charge premiums if the fund is insufficient", async () => {
-    //         // CASE 2 - Activate new policy for new policyholder. Deposit 1.1x WEEKLY_MAX_PREMIUM.
-    //         // We cannot reach PremiumPartiallyCharged branch within a single chargePremium() call, due to require(minAccountBalance) checks in activatePolicy, updateCoverLimit and chargePremium
-    //         // So aim to activate it on second chargePremium() call
+        it("can partially charge premiums if the fund is insufficient", async () => {
+            // CASE 2 - Activate new policy for new policyholder. Deposit 1.1x WEEKLY_MAX_PREMIUM.
+            // We cannot reach PremiumPartiallyCharged branch within a single chargePremium() call, due to require(minAccountBalance) checks in activatePolicy, updateCoverLimit and chargePremium
+            // So aim to activate it on second chargePremium() call
 
-    //         let depositAmount = WEEKLY_MAX_PREMIUM.mul(11).div(10)
+            let depositAmount = WEEKLY_MAX_PREMIUM.mul(11).div(10)
 
-    //         let tx = await soteriaCoverageProduct.connect(policyholder4).activatePolicy(policyholder4.address, INITIAL_COVER_LIMIT, {value: depositAmount});
-    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyCreated").withArgs(POLICY_ID_4);
+            let tx = await soteriaCoverageProduct.connect(policyholder4).activatePolicy(policyholder4.address, INITIAL_COVER_LIMIT, {value: depositAmount});
+            await expect(tx).emit(soteriaCoverageProduct, "PolicyCreated").withArgs(POLICY_ID_4);
 
-    //         let initialSoteriaBalance = await provider.getBalance(soteriaCoverageProduct.address);
-    //         let initialVaultBalance = await provider.getBalance(vault.address);
-    //         let initialHolderAccountBalance = await soteriaCoverageProduct.connect(policyholder4).accountBalanceOf(policyholder4.address);
-    //         let initialActiveCoverLimit = await soteriaCoverageProduct.connect(policyholder4).activeCoverLimit();
-    //         let initialPolicyCoverLimit = await soteriaCoverageProduct.connect(policyholder4).coverLimitOf(POLICY_ID_4);
-    //         let initialAvailableCoverCapacity = await soteriaCoverageProduct.connect(policyholder4).availableCoverCapacity();
-    //         let initialPMCoverAmount = await policyManager.connect(policyholder4).activeCoverAmount();
-    //         let initialPMSoteriaCoverAmount = await policyManager.connect(policyholder4).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
+            let initialSoteriaBalance = await provider.getBalance(soteriaCoverageProduct.address);
+            let initialVaultBalance = await provider.getBalance(vault.address);
+            let initialHolderAccountBalance = await soteriaCoverageProduct.connect(policyholder4).accountBalanceOf(policyholder4.address);
+            let initialActiveCoverLimit = await soteriaCoverageProduct.connect(policyholder4).activeCoverLimit();
+            let initialPolicyCoverLimit = await soteriaCoverageProduct.connect(policyholder4).coverLimitOf(POLICY_ID_4);
+            let initialAvailableCoverCapacity = await soteriaCoverageProduct.connect(policyholder4).availableCoverCapacity();
+            let initialPMCoverAmount = await policyManager.connect(policyholder4).activeCoverAmount();
+            let initialPMSoteriaCoverAmount = await policyManager.connect(policyholder4).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
 
-    //         // we cannot reach the PremiumPartiallyCharged branch within a single chargePremiums() call
-    //         await soteriaCoverageProduct.connect(governor).chargePremiums([policyholder4.address], [WEEKLY_MAX_PREMIUM]);
-    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder4.address)).eq(WEEKLY_MAX_PREMIUM.div(10))
-    //         tx = await soteriaCoverageProduct.connect(governor).chargePremiums([policyholder4.address], [WEEKLY_MAX_PREMIUM]);
-    //         await expect(tx).emit(soteriaCoverageProduct, "PremiumPartiallyCharged").withArgs(policyholder4.address, WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM.div(10));
+            // we cannot reach the PremiumPartiallyCharged branch within a single chargePremiums() call
+            await soteriaCoverageProduct.connect(governor).chargePremiums([policyholder4.address], [WEEKLY_MAX_PREMIUM]);
+            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder4.address)).eq(WEEKLY_MAX_PREMIUM.div(10))
+            tx = await soteriaCoverageProduct.connect(governor).chargePremiums([policyholder4.address], [WEEKLY_MAX_PREMIUM]);
+            await expect(tx).emit(soteriaCoverageProduct, "PremiumPartiallyCharged").withArgs(policyholder4.address, WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM.div(10));
            
-    //         // policy should be deactivated
-    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyDeactivated").withArgs(POLICY_ID_4);
-    //         expect(await soteriaCoverageProduct.connect(user).policyStatus(POLICY_ID_4)).to.equal(false);
+            // policy should be deactivated
+            await expect(tx).emit(soteriaCoverageProduct, "PolicyDeactivated").withArgs(POLICY_ID_4);
+            expect(await soteriaCoverageProduct.connect(user).policyStatus(POLICY_ID_4)).to.equal(false);
 
-    //         // active cover amount should be updated
-    //         expect(await soteriaCoverageProduct.connect(user).activeCoverLimit()).to.equal(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
-    //         expect(await soteriaCoverageProduct.connect(policyholder4).availableCoverCapacity()).eq(initialAvailableCoverCapacity.add(depositAmount).add(initialPolicyCoverLimit))
+            // active cover amount should be updated
+            expect(await soteriaCoverageProduct.connect(user).activeCoverLimit()).to.equal(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
+            expect(await soteriaCoverageProduct.connect(policyholder4).availableCoverCapacity()).eq(initialAvailableCoverCapacity.add(depositAmount).add(initialPolicyCoverLimit))
 
-    //         // policy's cover amount should be zero
-    //         expect(await soteriaCoverageProduct.connect(user).coverLimitOf(POLICY_ID_4)).to.equal(ZERO_AMOUNT);
+            // policy's cover amount should be zero
+            expect(await soteriaCoverageProduct.connect(user).coverLimitOf(POLICY_ID_4)).to.equal(ZERO_AMOUNT);
 
-    //         // policy manager should be updated
-    //         expect(await policyManager.connect(user).activeCoverAmount()).to.equal(initialPMCoverAmount.sub(initialPolicyCoverLimit));
-    //         expect(await policyManager.connect(user).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(initialPMSoteriaCoverAmount.sub(initialPolicyCoverLimit));
-    //         expect(await policyManager.connect(user).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
+            // policy manager should be updated
+            expect(await policyManager.connect(user).activeCoverAmount()).to.equal(initialPMCoverAmount.sub(initialPolicyCoverLimit));
+            expect(await policyManager.connect(user).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(initialPMSoteriaCoverAmount.sub(initialPolicyCoverLimit));
+            expect(await policyManager.connect(user).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
 
-    //         // policyholder funds should be zero
-    //         expect(await soteriaCoverageProduct.connect(user).accountBalanceOf(policyholder4.address)).to.equal(ZERO_AMOUNT);
+            // policyholder funds should be zero
+            expect(await soteriaCoverageProduct.connect(user).accountBalanceOf(policyholder4.address)).to.equal(ZERO_AMOUNT);
 
-    //         // soteria balance should be decreased
-    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(initialSoteriaBalance.sub(depositAmount));
+            // soteria balance should be decreased
+            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(initialSoteriaBalance.sub(depositAmount));
             
-    //         // premium should be sent to treasury
-    //         expect(await provider.getBalance(vault.address)).to.equal(initialVaultBalance.add(depositAmount));
-    //     });
+            // premium should be sent to treasury
+            expect(await provider.getBalance(vault.address)).to.equal(initialVaultBalance.add(depositAmount));
+        });
 
-    //     it("will skip charging premium for inactive accounts", async () => {
-    //         // CASE 3 - Charge weekly premium for one active, and one inactive account (made inactive in CASE 2)
+        it("will skip charging premium for inactive accounts", async () => {
+            // CASE 3 - Charge weekly premium for one active, and one inactive account (made inactive in CASE 2)
 
-    //         let initialSoteriaBalance = await provider.getBalance(soteriaCoverageProduct.address);
-    //         let initialVaultBalance = await provider.getBalance(vault.address);
-    //         let initialHolderFunds = await soteriaCoverageProduct.connect(policyholder2).accountBalanceOf(policyholder2.address);
+            let initialSoteriaBalance = await provider.getBalance(soteriaCoverageProduct.address);
+            let initialVaultBalance = await provider.getBalance(vault.address);
+            let initialHolderFunds = await soteriaCoverageProduct.connect(policyholder2).accountBalanceOf(policyholder2.address);
 
-    //         expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_4)).to.equal(false);
-    //         expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_2)).to.equal(true);
+            expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_4)).to.equal(false);
+            expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_2)).to.equal(true);
 
-    //         // charge premiums
-    //         let tx = soteriaCoverageProduct.connect(governor).chargePremiums([policyholder2.address, policyholder4.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM]);
-    //         await expect(tx).emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder2.address, WEEKLY_MAX_PREMIUM);
+            // charge premiums
+            let tx = soteriaCoverageProduct.connect(governor).chargePremiums([policyholder2.address, policyholder4.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM]);
+            await expect(tx).emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder2.address, WEEKLY_MAX_PREMIUM);
          
-    //         expect(await soteriaCoverageProduct.connect(policyholder2).accountBalanceOf(policyholder2.address)).to.equal(initialHolderFunds.sub(WEEKLY_MAX_PREMIUM));
+            expect(await soteriaCoverageProduct.connect(policyholder2).accountBalanceOf(policyholder2.address)).to.equal(initialHolderFunds.sub(WEEKLY_MAX_PREMIUM));
          
-    //         // soteria balance should be decreased by single weekly premium
-    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(initialSoteriaBalance.sub(WEEKLY_MAX_PREMIUM));
+            // soteria balance should be decreased by single weekly premium
+            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(initialSoteriaBalance.sub(WEEKLY_MAX_PREMIUM));
           
-    //         // single weekly premium should be sent to treasury
-    //         expect(await provider.getBalance(vault.address)).to.equal(initialVaultBalance.add(WEEKLY_MAX_PREMIUM));
-    //     });
+            // single weekly premium should be sent to treasury
+            expect(await provider.getBalance(vault.address)).to.equal(initialVaultBalance.add(WEEKLY_MAX_PREMIUM));
+        });
 
-    //     it("will correctly charge premiums with reward points", async () => {
-    //         // CASE 4 - Charge weekly premium for three active policies
-    //         // Policy 1: reward points can pay for premium in full
-    //         // Policy 2: reward points can partially pay for premium, rest will come from account balance
-    //         // Policy 3: reward points + account balance unable to fully pay for premium
+        it("will correctly charge premiums with reward points", async () => {
+            // CASE 4 - Charge weekly premium for three active policies
+            // Policy 1: reward points can pay for premium in full
+            // Policy 2: reward points can partially pay for premium, rest will come from account balance
+            // Policy 3: reward points + account balance unable to fully pay for premium
 
-    //         // Set up reward points for policy 1 and 2
-    //         let EXCESS_REWARD_POINTS = WEEKLY_MAX_PREMIUM.mul(2)
-    //         let INSUFFICIENT_REWARD_POINTS = WEEKLY_MAX_PREMIUM.div(10)
+            // Set up reward points for policy 1 and 2
+            let EXCESS_REWARD_POINTS = WEEKLY_MAX_PREMIUM.mul(2)
+            let INSUFFICIENT_REWARD_POINTS = WEEKLY_MAX_PREMIUM.div(10)
 
-    //         let tx = await soteriaCoverageProduct.connect(governor).setRewardPoints(policyholder1.address, EXCESS_REWARD_POINTS)
-    //         expect(tx).to.emit(soteriaCoverageProduct, "RewardPointsSet").withArgs(policyholder1.address, EXCESS_REWARD_POINTS);
-    //         let initialRewardPoints1 = await soteriaCoverageProduct.rewardPointsOf(policyholder1.address)
-    //         expect(initialRewardPoints1).eq(EXCESS_REWARD_POINTS)
+            let tx = await soteriaCoverageProduct.connect(governor).setRewardPoints(policyholder1.address, EXCESS_REWARD_POINTS)
+            expect(tx).to.emit(soteriaCoverageProduct, "RewardPointsSet").withArgs(policyholder1.address, EXCESS_REWARD_POINTS);
+            let initialRewardPoints1 = await soteriaCoverageProduct.rewardPointsOf(policyholder1.address)
+            expect(initialRewardPoints1).eq(EXCESS_REWARD_POINTS)
 
-    //         tx = await soteriaCoverageProduct.connect(governor).setRewardPoints(policyholder2.address, INSUFFICIENT_REWARD_POINTS)
-    //         expect(tx).to.emit(soteriaCoverageProduct, "RewardPointsSet").withArgs(policyholder2.address, INSUFFICIENT_REWARD_POINTS);
-    //         let initialRewardPoints2 = await soteriaCoverageProduct.rewardPointsOf(policyholder2.address)
-    //         expect(initialRewardPoints2).eq(INSUFFICIENT_REWARD_POINTS)
+            tx = await soteriaCoverageProduct.connect(governor).setRewardPoints(policyholder2.address, INSUFFICIENT_REWARD_POINTS)
+            expect(tx).to.emit(soteriaCoverageProduct, "RewardPointsSet").withArgs(policyholder2.address, INSUFFICIENT_REWARD_POINTS);
+            let initialRewardPoints2 = await soteriaCoverageProduct.rewardPointsOf(policyholder2.address)
+            expect(initialRewardPoints2).eq(INSUFFICIENT_REWARD_POINTS)
 
-    //         // Set up policy 3 (remember we need minimum 2 chargePremium calls to reach PremiumsPartiallySet branch, so we will do the first call to setup)
-    //         await soteriaCoverageProduct.connect(policyholder3).deactivatePolicy(POLICY_ID_3);
-    //         let depositAmount = WEEKLY_MAX_PREMIUM.mul(11).div(10)
-    //         await soteriaCoverageProduct.connect(policyholder3).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, {value: depositAmount});
-    //         await soteriaCoverageProduct.connect(governor).chargePremiums([policyholder3.address], [WEEKLY_MAX_PREMIUM]);
-    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).eq(WEEKLY_MAX_PREMIUM.div(10))
+            // Set up policy 3 (remember we need minimum 2 chargePremium calls to reach PremiumsPartiallySet branch, so we will do the first call to setup)
+            await soteriaCoverageProduct.connect(policyholder3).deactivatePolicy(POLICY_ID_3);
+            let depositAmount = WEEKLY_MAX_PREMIUM.mul(11).div(10)
+            await soteriaCoverageProduct.connect(policyholder3).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, {value: depositAmount});
+            await soteriaCoverageProduct.connect(governor).chargePremiums([policyholder3.address], [WEEKLY_MAX_PREMIUM]);
+            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).eq(WEEKLY_MAX_PREMIUM.div(10))
 
-    //         tx = await soteriaCoverageProduct.connect(governor).setRewardPoints(policyholder3.address, INSUFFICIENT_REWARD_POINTS)
-    //         expect(tx).to.emit(soteriaCoverageProduct, "RewardPointsSet").withArgs(policyholder3.address, INSUFFICIENT_REWARD_POINTS);
-    //         let initialRewardPoints3 = await soteriaCoverageProduct.rewardPointsOf(policyholder3.address)
-    //         expect(initialRewardPoints3).eq(INSUFFICIENT_REWARD_POINTS)
+            tx = await soteriaCoverageProduct.connect(governor).setRewardPoints(policyholder3.address, INSUFFICIENT_REWARD_POINTS)
+            expect(tx).to.emit(soteriaCoverageProduct, "RewardPointsSet").withArgs(policyholder3.address, INSUFFICIENT_REWARD_POINTS);
+            let initialRewardPoints3 = await soteriaCoverageProduct.rewardPointsOf(policyholder3.address)
+            expect(initialRewardPoints3).eq(INSUFFICIENT_REWARD_POINTS)
 
-    //         // Get initial state variable values
-    //         let initialSoteriaBalance = await provider.getBalance(soteriaCoverageProduct.address);
-    //         let initialVaultBalance = await provider.getBalance(vault.address);
-    //         let initialHolder1AccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
-    //         let initialHolder2AccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder2.address);
-    //         let initialHolder3AccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder3.address);
-    //         let initialActiveCoverLimit = await soteriaCoverageProduct.activeCoverLimit();
-    //         let initialPolicy1CoverLimit = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1);
-    //         let initialPolicy2CoverLimit = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2);
-    //         let initialPolicy3CoverLimit = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_3);
-    //         let initialAvailableCoverCapacity = await soteriaCoverageProduct.availableCoverCapacity();
-    //         let initialPMCoverAmount = await policyManager.activeCoverAmount();
-    //         let initialPMSoteriaCoverAmount = await policyManager.activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
+            // Get initial state variable values
+            let initialSoteriaBalance = await provider.getBalance(soteriaCoverageProduct.address);
+            let initialVaultBalance = await provider.getBalance(vault.address);
+            let initialHolder1AccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
+            let initialHolder2AccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder2.address);
+            let initialHolder3AccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder3.address);
+            let initialActiveCoverLimit = await soteriaCoverageProduct.activeCoverLimit();
+            let initialPolicy1CoverLimit = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1);
+            let initialPolicy2CoverLimit = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2);
+            let initialPolicy3CoverLimit = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_3);
+            let initialAvailableCoverCapacity = await soteriaCoverageProduct.availableCoverCapacity();
+            let initialPMCoverAmount = await policyManager.activeCoverAmount();
+            let initialPMSoteriaCoverAmount = await policyManager.activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
 
-    //         tx = await soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address, policyholder3.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM])
-    //         expect(tx).to.emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder1.address, WEEKLY_MAX_PREMIUM);
-    //         expect(tx).to.emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder2.address, WEEKLY_MAX_PREMIUM);
-    //         expect(tx).to.emit(soteriaCoverageProduct, "PremiumPartiallyCharged").withArgs(policyholder3.address, WEEKLY_MAX_PREMIUM, initialHolder3AccountBalance.add(initialRewardPoints3));
-    //         expect(tx).to.emit(soteriaCoverageProduct, "PolicyDeactivated").withArgs(POLICY_ID_3);
+            tx = await soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address, policyholder3.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM])
+            expect(tx).to.emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder1.address, WEEKLY_MAX_PREMIUM);
+            expect(tx).to.emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder2.address, WEEKLY_MAX_PREMIUM);
+            expect(tx).to.emit(soteriaCoverageProduct, "PremiumPartiallyCharged").withArgs(policyholder3.address, WEEKLY_MAX_PREMIUM, initialHolder3AccountBalance.add(initialRewardPoints3));
+            expect(tx).to.emit(soteriaCoverageProduct, "PolicyDeactivated").withArgs(POLICY_ID_3);
 
-    //         // Confirm state is what we expect after charging premium
+            // Confirm state is what we expect after charging premium
 
-    //         // Check reward points
-    //         expect(await soteriaCoverageProduct.rewardPointsOf(policyholder1.address)).eq(initialRewardPoints1.sub(WEEKLY_MAX_PREMIUM))            
-    //         expect(await soteriaCoverageProduct.rewardPointsOf(policyholder2.address)).eq(0)          
-    //         expect(await soteriaCoverageProduct.rewardPointsOf(policyholder2.address)).eq(0)          
+            // Check reward points
+            expect(await soteriaCoverageProduct.rewardPointsOf(policyholder1.address)).eq(initialRewardPoints1.sub(WEEKLY_MAX_PREMIUM))            
+            expect(await soteriaCoverageProduct.rewardPointsOf(policyholder2.address)).eq(0)          
+            expect(await soteriaCoverageProduct.rewardPointsOf(policyholder2.address)).eq(0)          
 
-    //         // Check account balances
-    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).eq(initialHolder1AccountBalance)
-    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder2.address)).eq(initialHolder2AccountBalance.sub(WEEKLY_MAX_PREMIUM).add(initialRewardPoints2))
-    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).eq(0)
+            // Check account balances
+            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).eq(initialHolder1AccountBalance)
+            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder2.address)).eq(initialHolder2AccountBalance.sub(WEEKLY_MAX_PREMIUM).add(initialRewardPoints2))
+            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).eq(0)
 
-    //         // Check cover limits
-    //         expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1)).eq(initialPolicy1CoverLimit)
-    //         expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2)).eq(initialPolicy2CoverLimit)
-    //         expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_3)).eq(0)
+            // Check cover limits
+            expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1)).eq(initialPolicy1CoverLimit)
+            expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2)).eq(initialPolicy2CoverLimit)
+            expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_3)).eq(0)
 
-    //         // Check policy status
-    //         expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_1)).eq(true)
-    //         expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_2)).eq(true)
-    //         expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_3)).eq(false)
+            // Check policy status
+            expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_1)).eq(true)
+            expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_2)).eq(true)
+            expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_3)).eq(false)
 
-    //         // Soteria balance check
-    //         let accountBalanceDeductedForHolder1 = BN.from("0");
-    //         let accountBalanceDeductedForHolder2 = WEEKLY_MAX_PREMIUM.sub(initialRewardPoints2);
-    //         let accountBalanceDeductedForHolder3 = initialHolder3AccountBalance;
-    //         let expectedSoteriaBalanceChange = accountBalanceDeductedForHolder1.add(accountBalanceDeductedForHolder2).add(accountBalanceDeductedForHolder3)
-    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).eq(initialSoteriaBalance.sub(expectedSoteriaBalanceChange))
+            // Soteria balance check
+            let accountBalanceDeductedForHolder1 = BN.from("0");
+            let accountBalanceDeductedForHolder2 = WEEKLY_MAX_PREMIUM.sub(initialRewardPoints2);
+            let accountBalanceDeductedForHolder3 = initialHolder3AccountBalance;
+            let expectedSoteriaBalanceChange = accountBalanceDeductedForHolder1.add(accountBalanceDeductedForHolder2).add(accountBalanceDeductedForHolder3)
+            expect(await provider.getBalance(soteriaCoverageProduct.address)).eq(initialSoteriaBalance.sub(expectedSoteriaBalanceChange))
 
-    //         // Vault balance check
-    //         expect(await provider.getBalance(vault.address)).eq(initialVaultBalance.add(expectedSoteriaBalanceChange))
+            // Vault balance check
+            expect(await provider.getBalance(vault.address)).eq(initialVaultBalance.add(expectedSoteriaBalanceChange))
 
-    //         // Soteria active cover limit check - policy 3 deactivated
-    //         expect(await soteriaCoverageProduct.activeCoverLimit()).eq(initialActiveCoverLimit.sub(initialPolicy3CoverLimit))
-    //         expect(await policyManager.activeCoverAmount()).eq(initialPMCoverAmount.sub(initialPolicy3CoverLimit))
-    //         expect(await policyManager.activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).eq(initialPMSoteriaCoverAmount.sub(initialPolicy3CoverLimit))
+            // Soteria active cover limit check - policy 3 deactivated
+            expect(await soteriaCoverageProduct.activeCoverLimit()).eq(initialActiveCoverLimit.sub(initialPolicy3CoverLimit))
+            expect(await policyManager.activeCoverAmount()).eq(initialPMCoverAmount.sub(initialPolicy3CoverLimit))
+            expect(await policyManager.activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).eq(initialPMSoteriaCoverAmount.sub(initialPolicy3CoverLimit))
             
-    //         // Cover capacity check - maxCover() increased by vault deposits, active cover limit decreased by policy 3 initial cover limit
-    //         expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity.add(expectedSoteriaBalanceChange).add(initialPolicy3CoverLimit))
-    //     })
+            // Cover capacity check - maxCover() increased by vault deposits, active cover limit decreased by policy 3 initial cover limit
+            expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity.add(expectedSoteriaBalanceChange).add(initialPolicy3CoverLimit))
+        })
 
-    //     it("will charge for 100 users in one call", async() => {
-    //         // Create 100 test wallets
-    //         // 100 wallets -> 1.6M gas
-    //         // 1000 wallets -> 16M gas
-    //         let numberWallets = 100 // Change this number to whatever number of wallets you want to test for
+        it("will charge for 100 users in one call", async() => {
+            // Create 100 test wallets
+            // 100 wallets -> 1.6M gas
+            // 1000 wallets -> 16M gas
+            let numberWallets = 100 // Change this number to whatever number of wallets you want to test for
 
-    //         let users:(Wallet)[] = [];
-    //         for (let i = 0; i < numberWallets; i++) {
-    //             users.push(provider.createEmptyWallet())
-    //         }
-    //         // Activate policies for each user, 1 ETH cover limit with 0.1 ETH deposit
-    //         for (let user of users) {
-    //             await soteriaCoverageProduct.connect(governor).activatePolicy(user.address, ONE_ETH, {value:ONE_ETH.div(10)})
-    //         }
-    //         // Gift 0 reward points to one-third of users, half-weekly premium to one-third, and full weekly premium to remaining third
-    //         for (let user of users) {
-    //             if ( Math.floor(Math.random() * 3) == 0 ) {
-    //                 await soteriaCoverageProduct.connect(governor).setRewardPoints(user.address, WEEKLY_MAX_PREMIUM.div(2))
-    //             } else if ( Math.floor(Math.random() * 3) == 1 ) {
-    //                 await soteriaCoverageProduct.connect(governor).setRewardPoints(user.address, WEEKLY_MAX_PREMIUM)
-    //             }
-    //         }
-    //         // Create arrays for chargePremium parameter
-    //         let PREMIUM_ARRAY:BN[] = []
-    //         let ADDRESS_ARRAY:string[] = []
-    //         for (let user of users) {
-    //             ADDRESS_ARRAY.push(user.address)
-    //             PREMIUM_ARRAY.push(WEEKLY_MAX_PREMIUM)
-    //         }
+            let users:(Wallet)[] = [];
+            for (let i = 0; i < numberWallets; i++) {
+                users.push(provider.createEmptyWallet())
+            }
+            // Activate policies for each user, 1 ETH cover limit with 0.1 ETH deposit
+            for (let user of users) {
+                await soteriaCoverageProduct.connect(governor).activatePolicy(user.address, ONE_ETH, {value:ONE_ETH.div(10)})
+            }
+            // Gift 0 reward points to one-third of users, half-weekly premium to one-third, and full weekly premium to remaining third
+            for (let user of users) {
+                if ( Math.floor(Math.random() * 3) == 0 ) {
+                    await soteriaCoverageProduct.connect(governor).setRewardPoints(user.address, WEEKLY_MAX_PREMIUM.div(2))
+                } else if ( Math.floor(Math.random() * 3) == 1 ) {
+                    await soteriaCoverageProduct.connect(governor).setRewardPoints(user.address, WEEKLY_MAX_PREMIUM)
+                }
+            }
+            // Create arrays for chargePremium parameter
+            let PREMIUM_ARRAY:BN[] = []
+            let ADDRESS_ARRAY:string[] = []
+            for (let user of users) {
+                ADDRESS_ARRAY.push(user.address)
+                PREMIUM_ARRAY.push(WEEKLY_MAX_PREMIUM)
+            }
 
-    //         // Charge premiums
-    //         await soteriaCoverageProduct.connect(governor).chargePremiums(ADDRESS_ARRAY, PREMIUM_ARRAY);
-    //     })
-    // // Test for maxing out users
+            // Charge premiums
+            await soteriaCoverageProduct.connect(governor).chargePremiums(ADDRESS_ARRAY, PREMIUM_ARRAY);
+        })
+    // Test for maxing out users
 
-    // });
+    });
 
 });

--- a/test/SoteriaCoverageProduct.test.ts
+++ b/test/SoteriaCoverageProduct.test.ts
@@ -36,11 +36,13 @@ describe("SoteriaCoverageProduct", function() {
     const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
     const COVER_AMOUNT = BN.from("1000000000000000000"); // 1 eth
     const NEW_COVER_AMOUNT = BN.from("2000000000000000000"); // 2 eth
+    const ONE_TENTH_ETH = BN.from("100000000000000000"); // 0.1 eth
     const ONE_ETH = BN.from("1000000000000000000"); // 1 eth
+    const TWO_ETH = BN.from("2000000000000000000"); // 1 eth
     const ZERO_AMOUNT = BN.from("0");
     const PREMIUM_AMOUNT = BN.from("100000000000000000"); // 0.1 eth
-    const TOKEN0 = "0x501ace9c35e60f03a2af4d484f49f9b1efde9f40";
-    const TOKEN1 = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+    const TOKEN0 = "0x501ace9c35e60f03a2af4d484f49f9b1efde9f40"; // SOLACE.sol
+    const TOKEN1 = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"; // USDC.sol
     const RESERVE0 = BN.from("13250148273341498385651903");
     const RESERVE1 = BN.from("1277929641956");
     const STRATEGY_STATUS = {
@@ -52,6 +54,9 @@ describe("SoteriaCoverageProduct", function() {
     const POLICY_ID_2 = BN.from("2");
     const POLICY_ID_3 = BN.from("3");
     const POLICY_ID_4 = BN.from("4");
+    const ONE_WEEK = BN.from("604800");
+    const maxRateNum = BN.from("1");
+    const maxRateDenom = BN.from("315360000"); // We are testing with maxRateNum and maxRateDenom that gives us an annual max rate of 10% coverLimit
 
     before( async () => {
         artifacts = await import_artifacts();
@@ -224,7 +229,53 @@ describe("SoteriaCoverageProduct", function() {
         });
     });
 
-    describe("buyPolicy", () => {
+    describe("setMaxRateNum & setMaxRateDenom", () => {
+        it("cannot be set by non governance", async () => {
+            await expect(soteriaCoverageProduct.connect(policyholder1).setMaxRateNum(1)).to.revertedWith("!governance");
+            await expect(soteriaCoverageProduct.connect(policyholder1).setMaxRateDenom(1)).to.revertedWith("!governance");
+        });
+        it("can be set", async () => {
+            let tx1 = await soteriaCoverageProduct.connect(governor).setMaxRateNum(maxRateNum)
+            let tx2 = await soteriaCoverageProduct.connect(governor).setMaxRateDenom(maxRateDenom)
+            expect(tx1).emit(soteriaCoverageProduct, "MaxRateNumSet").withArgs(maxRateNum);
+            expect(tx2).emit(soteriaCoverageProduct, "MaxRateDenomSet").withArgs(maxRateDenom);
+        })
+        it("getter functions working", async () => {
+            expect(await soteriaCoverageProduct.maxRateNum()).eq(maxRateNum)
+            expect(await soteriaCoverageProduct.maxRateDenom()).eq(maxRateDenom)
+        })
+    })
+
+    describe("setChargeCycle", () => {
+        it("cannot be set by non governance", async () => {
+            await expect(soteriaCoverageProduct.connect(policyholder1).setChargeCycle(1)).to.revertedWith("!governance");
+        });
+        it("can be set", async () => {
+            let tx = await soteriaCoverageProduct.connect(governor).setChargeCycle(ONE_WEEK)
+            expect(tx).emit(soteriaCoverageProduct, "ChargeCycleSet").withArgs(ONE_WEEK);
+        })
+        it("getter functions working", async () => {
+            expect(await soteriaCoverageProduct.chargeCycle()).eq(ONE_WEEK)
+        })
+    })
+
+    describe("setRewardPoints", () => {
+        it("cannot be set by non governance", async () => {
+            await expect(soteriaCoverageProduct.connect(policyholder1).setRewardPoints(policyholder1.address, 1)).to.revertedWith("!governance");
+        });
+        it("can be set", async () => {
+            let tx = await soteriaCoverageProduct.connect(governor).setRewardPoints(policyholder1.address, 1)
+            expect(tx).emit(soteriaCoverageProduct, "RewardPointsSet").withArgs(policyholder1.address, BN.from("1"));
+        })
+        it("getter functions working", async () => {
+            expect(await soteriaCoverageProduct.rewardPointsOf(policyholder1.address)).eq(BN.from("1"))
+        })
+        after(async () => {
+            await soteriaCoverageProduct.connect(governor).setRewardPoints(policyholder1.address, 0)
+        })
+    })
+
+    describe("activatePolicy", () => {
         let pmActiveCoverAmount:BN;
         let pmSoteriaActiveCoverAmount: BN;
         let mcr: BN;
@@ -242,380 +293,360 @@ describe("SoteriaCoverageProduct", function() {
             mcrps = await riskManager.connect(governor).minCapitalRequirementPerStrategy(soteriaCoverageProduct.address);
         });
 
-        it("cannot buy policy when zero address policy holder is provided", async () => {
-            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(ZERO_ADDRESS, COVER_AMOUNT, PREMIUM_AMOUNT)).to.revertedWith("zero address policyholder");
+        it("cannot activate policy when zero address policy holder is provided", async () => {
+            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(ZERO_ADDRESS, COVER_AMOUNT)).to.revertedWith("zero address policyholder");
         });
 
-        it("cannot buy policy when zero cover amaount value is provided", async () => {
-            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, ZERO_AMOUNT, PREMIUM_AMOUNT)).to.revertedWith("zero cover value");
-        });
-
-        it("cannot buy policy when zero msg.value is provided", async () => {
-            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, COVER_AMOUNT, PREMIUM_AMOUNT, {value: ZERO_AMOUNT})).to.revertedWith("insufficient fund");
-        });
-
-        it("cannot buy policy when risk is not accepted", async () => {
-            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, COVER_AMOUNT, PREMIUM_AMOUNT, {value: ONE_ETH})).to.revertedWith("cannot accept that risk");
+        it("cannot buy policy when zero cover amount value is provided", async () => {
+            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, ZERO_AMOUNT)).to.revertedWith("zero cover value");
         });
 
         it("cannot buy policy when contract is paused", async () => {
             await soteriaCoverageProduct.connect(governor).setPaused(true);
-            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, COVER_AMOUNT, PREMIUM_AMOUNT, {value: ONE_ETH})).to.revertedWith("contract paused");
+            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, COVER_AMOUNT, {value: ONE_ETH})).to.revertedWith("contract paused");
             await soteriaCoverageProduct.connect(governor).setPaused(false);
         });
 
-        it("can buy policy", async () => {
+        it("can cannot purchase a policy before Coverage Data Provider and Risk Manager are set up (maxCover = 0)", async () => {
+            expect (await soteriaCoverageProduct.maxCover()).eq(0)
+            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, COVER_AMOUNT, {value: ZERO_AMOUNT})).to.revertedWith("insufficient capacity for new cover");
+        })
+
+        it("can setup Coverage Data Provider and Risk Manager", async () => {
             // add underwriting pool to the coverage data provider
             let maxCover1 = await riskManager.connect(governor).maxCover();
             expect(maxCover1).to.equal(0)
             expect(await coverageDataProvider.connect(governor).numOfPools()).to.equal(0);
+
             await coverageDataProvider.connect(governor).addPools([underwritingPool.address]);
             expect(await coverageDataProvider.connect(governor).numOfPools()).to.equal(1);
-
             let uwpETHBalance = await underwritingPool.getBalance();
             let maxCover2 = await riskManager.connect(governor).maxCover();
             expect(maxCover2).to.equal(maxCover1.add(uwpETHBalance));
-
+            
             // add Soteria to the risk manager and assign coverage allocation
             await riskManager.connect(governor).addRiskStrategy(soteriaCoverageProduct.address);
             await riskManager.connect(governor).setStrategyStatus(soteriaCoverageProduct.address, STRATEGY_STATUS.ACTIVE);
             await riskManager.connect(governor).setWeightAllocation(soteriaCoverageProduct.address, 1000);
             expect(await riskManager.connect(governor).maxCoverPerStrategy(soteriaCoverageProduct.address)).to.equal(maxCover2);
-    
-            // buy policy
-            let tx = await soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, COVER_AMOUNT, PREMIUM_AMOUNT, {value: ONE_ETH});
+            expect(await riskManager.connect(governor).maxCoverPerStrategy(soteriaCoverageProduct.address)).to.equal(await soteriaCoverageProduct.maxCover());
+        })
+
+        it("cannot buy policy when max cover exceeded", async () => {
+            let maxCover = await soteriaCoverageProduct.maxCover();
+            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, maxCover.add(1), {value: ONE_ETH})).to.revertedWith("insufficient capacity for new cover");
+        });
+
+        it("cannot buy policy when insufficient deposit provided", async () => {
+            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, ONE_ETH, {value: ZERO_AMOUNT})).to.revertedWith("insufficient deposit for minimum required account balance");
+        });
+
+        it("can activate policy - 1 ETH cover with 1 ETH deposit", async () => {
+            let tx = await soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, ONE_ETH, {value: ONE_ETH});
+
             await expect(tx).emit(soteriaCoverageProduct, "PolicyCreated").withArgs(POLICY_ID_1);
-            expect(await soteriaCoverageProduct.connect(policyholder1).activeCoverAmount()).to.equal(COVER_AMOUNT);
-            expect(await soteriaCoverageProduct.connect(policyholder1).policyCount()).to.equal(1);
-            expect(await soteriaCoverageProduct.connect(policyholder1).coverAmountOf(POLICY_ID_1)).to.equal(COVER_AMOUNT);
-            expect(await soteriaCoverageProduct.connect(policyholder1).funds(policyholder1.address)).to.equal(ONE_ETH);
+            await expect(tx).emit(soteriaCoverageProduct, "Transfer").withArgs(ZERO_ADDRESS, policyholder1.address, POLICY_ID_1);
+
+            expect (await soteriaCoverageProduct.rewardPointsOf(policyholder1.address)).eq(0)
+            expect (await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).eq(ONE_ETH)
+            expect (await soteriaCoverageProduct.policyStatus(POLICY_ID_1)).eq(true)
+            expect (await soteriaCoverageProduct.policyOf(policyholder1.address)).eq(POLICY_ID_1)
+            expect (await soteriaCoverageProduct.ownerOf(POLICY_ID_1)).eq(policyholder1.address)
+            expect (await soteriaCoverageProduct.activeCoverLimit()).eq(ONE_ETH)
+            expect (await soteriaCoverageProduct.policyCount()).eq(1)
+            expect (await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1)).eq(ONE_ETH)
             expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(ONE_ETH);
         });
 
-        it("can buy policy on behalf of the policy holder", async () => {
-            let tx = await soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder2.address, COVER_AMOUNT, PREMIUM_AMOUNT, {value: ONE_ETH});
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyCreated").withArgs(POLICY_ID_2);
-            expect(await soteriaCoverageProduct.connect(policyholder1).activeCoverAmount()).to.equal(COVER_AMOUNT.mul(2));
-            expect(await soteriaCoverageProduct.connect(policyholder1).policyCount()).to.equal(2);
-            expect(await soteriaCoverageProduct.connect(policyholder1).coverAmountOf(POLICY_ID_2)).to.equal(COVER_AMOUNT);
-            expect(await soteriaCoverageProduct.connect(policyholder1).funds(policyholder2.address)).to.equal(ONE_ETH);
-            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(ONE_ETH.mul(2));
-        });
+        it("cannot purchase more than one policy for a single address", async () => {
+            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, ONE_ETH, {value: ONE_ETH})).to.be.revertedWith("already bought policy")
+            await expect(soteriaCoverageProduct.connect(policyholder2).activatePolicy(policyholder1.address, ONE_ETH, {value: ONE_ETH})).to.be.revertedWith("already bought policy")
+        })
+        
+        it("cannot transfer policy", async () => {
+            await expect(soteriaCoverageProduct.connect(policyholder1).transferFrom(policyholder1.address, policyholder2.address, 1)).to.be.revertedWith("only minting permitted");
+            await expect(soteriaCoverageProduct.connect(policyholder1).transferFrom(policyholder1.address, ZERO_ADDRESS, 1)).to.be.revertedWith("ERC721: transfer to the zero address");
+            // TO-DO, test ERC721.safeTransferFrom() => TypeError: soteriaCoverageProduct.connect(...).safeTransferFrom is not a function
+        })
 
-        it("cannot buy policy if policy holder has already bought for soteria", async () => {
-            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, COVER_AMOUNT, PREMIUM_AMOUNT, {value: ONE_ETH})).to.revertedWith("already bought policy");
-        });
+    // //     it("can buy policy on behalf of the policy holder", async () => {
+    // //         let tx = await soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder2.address, COVER_AMOUNT, PREMIUM_AMOUNT, {value: ONE_ETH});
+    // //         await expect(tx).emit(soteriaCoverageProduct, "PolicyCreated").withArgs(POLICY_ID_2);
+    // //         expect(await soteriaCoverageProduct.connect(policyholder1).activeCoverAmount()).to.equal(COVER_AMOUNT.mul(2));
+    // //         expect(await soteriaCoverageProduct.connect(policyholder1).policyCount()).to.equal(2);
+    // //         expect(await soteriaCoverageProduct.connect(policyholder1).coverAmountOf(POLICY_ID_2)).to.equal(COVER_AMOUNT);
+    // //         expect(await soteriaCoverageProduct.connect(policyholder1).funds(policyholder2.address)).to.equal(ONE_ETH);
+    // //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(ONE_ETH.mul(2));
+    // //     });
 
-        it("policy holder should have policy nft after buying coverage", async () => {
-            expect(await soteriaCoverageProduct.connect(policyholder1).balanceOf(policyholder1.address)).to.equal(1);
-            expect(await soteriaCoverageProduct.connect(policyholder2).balanceOf(policyholder2.address)).to.equal(1);
-        });
 
-        it("can query via policy id", async () => {
-            expect(await soteriaCoverageProduct.connect(policyholder1).ownerOfPolicy(POLICY_ID_1)).to.equal(policyholder1.address);
-            expect(await soteriaCoverageProduct.connect(policyholder2).ownerOfPolicy(POLICY_ID_2)).to.equal(policyholder2.address);
-        });
+    // //     it("policy holder should have policy nft after buying coverage", async () => {
+    // //         expect(await soteriaCoverageProduct.connect(policyholder1).balanceOf(policyholder1.address)).to.equal(1);
+    // //         expect(await soteriaCoverageProduct.connect(policyholder2).balanceOf(policyholder2.address)).to.equal(1);
+    // //     });
 
-        it("can query via owner", async () => {
-            expect(await soteriaCoverageProduct.connect(policyholder1).policyByOwner(policyholder1.address)).to.equal(POLICY_ID_1);
-            expect(await soteriaCoverageProduct.connect(policyholder2).policyByOwner(policyholder2.address)).to.equal(POLICY_ID_2);
-        });
 
-        it("can query all holders", async () => {
-            let holders = await soteriaCoverageProduct.connect(policyholder1).policyholders();
-            expect(holders.length).to.equal(await soteriaCoverageProduct.policyCount());
-        });
+    // //     it("should update policy manager active cover amount", async () => {
+    // //         let activeCoverAmount = await soteriaCoverageProduct.connect(governor).activeCoverAmount();
+    // //         expect(await policyManager.connect(governor).activeCoverAmount()).to.equal(pmActiveCoverAmount.add(activeCoverAmount));
+    // //         expect(await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(pmSoteriaActiveCoverAmount.add(activeCoverAmount));
+    // //     });
 
-        it("should update policy manager active cover amount", async () => {
-            let activeCoverAmount = await soteriaCoverageProduct.connect(governor).activeCoverAmount();
-            expect(await policyManager.connect(governor).activeCoverAmount()).to.equal(pmActiveCoverAmount.add(activeCoverAmount));
-            expect(await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(pmSoteriaActiveCoverAmount.add(activeCoverAmount));
-        });
-
-        it("should update risk manager mcr", async () => {
-            let activeCoverAmount = await soteriaCoverageProduct.connect(governor).activeCoverAmount();
-            expect(await riskManager.connect(governor).minCapitalRequirement()).to.equal(mcr.add(activeCoverAmount));
-            expect(await riskManager.connect(governor).minCapitalRequirementPerStrategy(soteriaCoverageProduct.address)).to.equal(mcrps.add(activeCoverAmount));
-        });
+    // //     it("should update risk manager mcr", async () => {
+    // //         let activeCoverAmount = await soteriaCoverageProduct.connect(governor).activeCoverAmount();
+    // //         expect(await riskManager.connect(governor).minCapitalRequirement()).to.equal(mcr.add(activeCoverAmount));
+    // //         expect(await riskManager.connect(governor).minCapitalRequirementPerStrategy(soteriaCoverageProduct.address)).to.equal(mcrps.add(activeCoverAmount));
+    // //     });
     });
 
-    describe("deposit", () => {
-        it("can deposit", async () => {
-            let funds = await soteriaCoverageProduct.connect(policyholder1).funds(policyholder1.address);
-            let balance = await provider.getBalance(soteriaCoverageProduct.address);
-            let tx = await soteriaCoverageProduct.connect(policyholder1).deposit(policyholder1.address, { value: ONE_ETH });
-            await expect(tx).emit(soteriaCoverageProduct, "DepositMade").withArgs(policyholder1.address, ONE_ETH);
-            expect(await soteriaCoverageProduct.funds(policyholder1.address)).to.equal(funds.add(ONE_ETH));
-            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(balance.add(ONE_ETH));
-        });
+    // describe("deposit", () => {
+    //     it("can deposit", async () => {
+    //         let funds = await soteriaCoverageProduct.connect(policyholder1).funds(policyholder1.address);
+    //         let balance = await provider.getBalance(soteriaCoverageProduct.address);
+    //         let tx = await soteriaCoverageProduct.connect(policyholder1).deposit(policyholder1.address, { value: ONE_ETH });
+    //         await expect(tx).emit(soteriaCoverageProduct, "DepositMade").withArgs(policyholder1.address, ONE_ETH);
+    //         expect(await soteriaCoverageProduct.funds(policyholder1.address)).to.equal(funds.add(ONE_ETH));
+    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(balance.add(ONE_ETH));
+    //     });
 
-        it("can deposit on behalf of policy holder", async () => {
-            let funds = await soteriaCoverageProduct.connect(policyholder1).funds(policyholder2.address);
-            let balance = await provider.getBalance(soteriaCoverageProduct.address);
-            let tx = await soteriaCoverageProduct.connect(policyholder1).deposit(policyholder2.address, { value: ONE_ETH });
-            await expect(tx).emit(soteriaCoverageProduct, "DepositMade").withArgs(policyholder2.address, ONE_ETH);
-            expect(await soteriaCoverageProduct.funds(policyholder2.address)).to.equal(funds.add(ONE_ETH));
-            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(balance.add(ONE_ETH));
-        });
+    //     it("can deposit on behalf of policy holder", async () => {
+    //         let funds = await soteriaCoverageProduct.connect(policyholder1).funds(policyholder2.address);
+    //         let balance = await provider.getBalance(soteriaCoverageProduct.address);
+    //         let tx = await soteriaCoverageProduct.connect(policyholder1).deposit(policyholder2.address, { value: ONE_ETH });
+    //         await expect(tx).emit(soteriaCoverageProduct, "DepositMade").withArgs(policyholder2.address, ONE_ETH);
+    //         expect(await soteriaCoverageProduct.funds(policyholder2.address)).to.equal(funds.add(ONE_ETH));
+    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(balance.add(ONE_ETH));
+    //     });
 
-        it("can deposit via fallback", async () => {
-            let funds = await soteriaCoverageProduct.connect(policyholder1).funds(policyholder1.address);
-            let balance = await provider.getBalance(soteriaCoverageProduct.address);
-            let tx = await policyholder1.sendTransaction({ to: soteriaCoverageProduct.address, value: ONE_ETH });
-            await expect(tx).emit(soteriaCoverageProduct, "DepositMade").withArgs(policyholder1.address, ONE_ETH);
-            expect(await soteriaCoverageProduct.funds(policyholder1.address)).to.equal(funds.add(ONE_ETH));
-            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(balance.add(ONE_ETH));
-        });
+    //     it("can deposit via fallback", async () => {
+    //         let funds = await soteriaCoverageProduct.connect(policyholder1).funds(policyholder1.address);
+    //         let balance = await provider.getBalance(soteriaCoverageProduct.address);
+    //         let tx = await policyholder1.sendTransaction({ to: soteriaCoverageProduct.address, value: ONE_ETH });
+    //         await expect(tx).emit(soteriaCoverageProduct, "DepositMade").withArgs(policyholder1.address, ONE_ETH);
+    //         expect(await soteriaCoverageProduct.funds(policyholder1.address)).to.equal(funds.add(ONE_ETH));
+    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(balance.add(ONE_ETH));
+    //     });
 
-        it("cannot deposit while paused", async () => {
-            await soteriaCoverageProduct.connect(governor).setPaused(true);
-            await expect(soteriaCoverageProduct.connect(policyholder1).deposit(policyholder1.address, { value: ONE_ETH })).to.revertedWith("contract paused");
-            await soteriaCoverageProduct.connect(governor).setPaused(false);
-        });
-    });
+    //     it("cannot deposit while paused", async () => {
+    //         await soteriaCoverageProduct.connect(governor).setPaused(true);
+    //         await expect(soteriaCoverageProduct.connect(policyholder1).deposit(policyholder1.address, { value: ONE_ETH })).to.revertedWith("contract paused");
+    //         await soteriaCoverageProduct.connect(governor).setPaused(false);
+    //     });
+    // });
 
-    describe("updateCoverAmount", () => {
-        let maxCover: BN;
-        let maxCoverPerStrategy: BN;
-        let prevMCRForSoteria: BN;
-        let prevMCR: BN; // min. capital requirement
-        let prevSoteriaActiveCoverAmount: BN;
-        let prevPolicyCoverAmount: BN;
-        let prevPMActiveCoverAmount: BN; // policy manager active cover amount
-        let prevPMActiveCoverAmountForSoteria: BN; // policy manager active cover amount for soteria
+    // describe("updateCoverAmount", () => {
+    //     let maxCover: BN;
+    //     let maxCoverPerStrategy: BN;
+    //     let prevMCRForSoteria: BN;
+    //     let prevMCR: BN; // min. capital requirement
+    //     let prevSoteriaActiveCoverAmount: BN;
+    //     let prevPolicyCoverAmount: BN;
+    //     let prevPMActiveCoverAmount: BN; // policy manager active cover amount
+    //     let prevPMActiveCoverAmountForSoteria: BN; // policy manager active cover amount for soteria
 
-        before(async () => {
-            maxCover = await riskManager.connect(governor).maxCover();
-            maxCoverPerStrategy = await riskManager.connect(governor).maxCoverPerStrategy(soteriaCoverageProduct.address);
+    //     before(async () => {
+    //         maxCover = await riskManager.connect(governor).maxCover();
+    //         maxCoverPerStrategy = await riskManager.connect(governor).maxCoverPerStrategy(soteriaCoverageProduct.address);
 
-            // risk manager current values
-            prevMCR = await riskManager.connect(governor).minCapitalRequirement();
-            prevMCRForSoteria = await riskManager.connect(governor).minCapitalRequirementPerStrategy(soteriaCoverageProduct.address);
+    //         // risk manager current values
+    //         prevMCR = await riskManager.connect(governor).minCapitalRequirement();
+    //         prevMCRForSoteria = await riskManager.connect(governor).minCapitalRequirementPerStrategy(soteriaCoverageProduct.address);
             
-            // policy manager current values
-            prevPMActiveCoverAmount = await policyManager.connect(governor).activeCoverAmount();
-            prevPMActiveCoverAmountForSoteria = await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
+    //         // policy manager current values
+    //         prevPMActiveCoverAmount = await policyManager.connect(governor).activeCoverAmount();
+    //         prevPMActiveCoverAmountForSoteria = await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
 
-            prevSoteriaActiveCoverAmount = await soteriaCoverageProduct.connect(policyholder1).activeCoverAmount();
-            prevPolicyCoverAmount = await soteriaCoverageProduct.connect(policyholder1).coverAmountOf(POLICY_ID_1);
+    //         prevSoteriaActiveCoverAmount = await soteriaCoverageProduct.connect(policyholder1).activeCoverAmount();
+    //         prevPolicyCoverAmount = await soteriaCoverageProduct.connect(policyholder1).coverAmountOf(POLICY_ID_1);
 
-            expect(await soteriaCoverageProduct.connect(policyholder1).ownerOfPolicy(POLICY_ID_1)).to.equal(policyholder1.address);
-            expect(await soteriaCoverageProduct.connect(policyholder1).ownerOf(POLICY_ID_1)).to.equal(policyholder1.address);
-        });
+    //         expect(await soteriaCoverageProduct.connect(policyholder1).ownerOfPolicy(POLICY_ID_1)).to.equal(policyholder1.address);
+    //         expect(await soteriaCoverageProduct.connect(policyholder1).ownerOf(POLICY_ID_1)).to.equal(policyholder1.address);
+    //     });
 
-        it("cannot update for zero cover amount", async () => {
-            await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverAmount(ZERO_AMOUNT)).to.revertedWith("zero cover value");
-        });
+    //     it("cannot update for zero cover amount", async () => {
+    //         await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverAmount(ZERO_AMOUNT)).to.revertedWith("zero cover value");
+    //     });
 
-        it("cannot update for invalid policy", async () => {
-            await expect(soteriaCoverageProduct.connect(governor).updateCoverAmount(NEW_COVER_AMOUNT)).to.revertedWith("invalid policy");
-        });
+    //     it("cannot update for invalid policy", async () => {
+    //         await expect(soteriaCoverageProduct.connect(governor).updateCoverAmount(NEW_COVER_AMOUNT)).to.revertedWith("invalid policy");
+    //     });
 
-        it("cannot update while paused", async () => {
-            await soteriaCoverageProduct.connect(governor).setPaused(true);
-            await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverAmount(NEW_COVER_AMOUNT)).to.revertedWith("contract paused");
-            await soteriaCoverageProduct.connect(governor).setPaused(false);
-        });
+    //     it("cannot update while paused", async () => {
+    //         await soteriaCoverageProduct.connect(governor).setPaused(true);
+    //         await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverAmount(NEW_COVER_AMOUNT)).to.revertedWith("contract paused");
+    //         await soteriaCoverageProduct.connect(governor).setPaused(false);
+    //     });
 
-        it("cannot update if max cover is exceeded", async () => {
-            await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverAmount(maxCover.add(1))).to.revertedWith("cannot accept that risk");
-        });
+    //     it("cannot update if max cover is exceeded", async () => {
+    //         await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverAmount(maxCover.add(1))).to.revertedWith("cannot accept that risk");
+    //     });
 
-        it("cannot update if max cover for the strategy is exceeded", async () => {
-            await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverAmount(maxCoverPerStrategy.add(1))).to.revertedWith("cannot accept that risk");
-        });
+    //     it("cannot update if max cover for the strategy is exceeded", async () => {
+    //         await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverAmount(maxCoverPerStrategy.add(1))).to.revertedWith("cannot accept that risk");
+    //     });
 
-        it("can update policy", async () => {
-            let tx = await soteriaCoverageProduct.connect(policyholder1).updateCoverAmount(NEW_COVER_AMOUNT);
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyUpdated").withArgs(POLICY_ID_1);
-            let activeCoverAmount = prevSoteriaActiveCoverAmount.add(NEW_COVER_AMOUNT).sub(prevPolicyCoverAmount);
-            expect(await soteriaCoverageProduct.connect(policyholder1).activeCoverAmount()).to.equal(activeCoverAmount);
-            expect(await soteriaCoverageProduct.connect(policyholder1).coverAmountOf(POLICY_ID_1)).to.equal(NEW_COVER_AMOUNT);
-        });
+    //     it("can update policy", async () => {
+    //         let tx = await soteriaCoverageProduct.connect(policyholder1).updateCoverAmount(NEW_COVER_AMOUNT);
+    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyUpdated").withArgs(POLICY_ID_1);
+    //         let activeCoverAmount = prevSoteriaActiveCoverAmount.add(NEW_COVER_AMOUNT).sub(prevPolicyCoverAmount);
+    //         expect(await soteriaCoverageProduct.connect(policyholder1).activeCoverAmount()).to.equal(activeCoverAmount);
+    //         expect(await soteriaCoverageProduct.connect(policyholder1).coverAmountOf(POLICY_ID_1)).to.equal(NEW_COVER_AMOUNT);
+    //     });
 
-        it("should update policy manager active cover amount", async () => {
-            let amount1 = prevPMActiveCoverAmount.add(NEW_COVER_AMOUNT).sub(prevPolicyCoverAmount);
-            let amount2 = prevPMActiveCoverAmountForSoteria.add(NEW_COVER_AMOUNT).sub(prevPolicyCoverAmount);
+    //     it("should update policy manager active cover amount", async () => {
+    //         let amount1 = prevPMActiveCoverAmount.add(NEW_COVER_AMOUNT).sub(prevPolicyCoverAmount);
+    //         let amount2 = prevPMActiveCoverAmountForSoteria.add(NEW_COVER_AMOUNT).sub(prevPolicyCoverAmount);
 
-            expect(await policyManager.connect(governor).activeCoverAmount()).to.equal(amount1);
-            expect(await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(amount2);
-        });
+    //         expect(await policyManager.connect(governor).activeCoverAmount()).to.equal(amount1);
+    //         expect(await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(amount2);
+    //     });
 
-        it("should update risk manager mcr", async () => {         
-            let amount1 = prevMCR.add(NEW_COVER_AMOUNT).sub(prevPolicyCoverAmount);
-            let amount2 = prevMCRForSoteria.add(NEW_COVER_AMOUNT).sub(prevPolicyCoverAmount);
-            expect(await riskManager.connect(governor).minCapitalRequirement()).to.equal(amount1);
-            expect(await riskManager.connect(governor).minCapitalRequirementPerStrategy(soteriaCoverageProduct.address)).to.equal(amount2);
-        });
-    });
+    //     it("should update risk manager mcr", async () => {         
+    //         let amount1 = prevMCR.add(NEW_COVER_AMOUNT).sub(prevPolicyCoverAmount);
+    //         let amount2 = prevMCRForSoteria.add(NEW_COVER_AMOUNT).sub(prevPolicyCoverAmount);
+    //         expect(await riskManager.connect(governor).minCapitalRequirement()).to.equal(amount1);
+    //         expect(await riskManager.connect(governor).minCapitalRequirementPerStrategy(soteriaCoverageProduct.address)).to.equal(amount2);
+    //     });
+    // });
 
-    describe("cancelPolicy", () => {
-        before(async () => {
-            let tx = await soteriaCoverageProduct.connect(policyholder3).activatePolicy(policyholder3.address, COVER_AMOUNT, PREMIUM_AMOUNT, {value: ONE_ETH});
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyCreated").withArgs(POLICY_ID_3);
-        });
+    // describe("cancelPolicy", () => {
+    //     before(async () => {
+    //         let tx = await soteriaCoverageProduct.connect(policyholder3).activatePolicy(policyholder3.address, COVER_AMOUNT, PREMIUM_AMOUNT, {value: ONE_ETH});
+    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyCreated").withArgs(POLICY_ID_3);
+    //     });
 
-        it("cannot cancel for invalid policy", async () => {
-            await expect(soteriaCoverageProduct.connect(policyholder3).cancelPolicy(INVALID_POLICY_ID)).to.revertedWith("invalid policy");
-        });
+    //     it("cannot cancel for invalid policy", async () => {
+    //         await expect(soteriaCoverageProduct.connect(policyholder3).cancelPolicy(INVALID_POLICY_ID)).to.revertedWith("invalid policy");
+    //     });
 
-        it("cannot cancel someone's policy", async () => {
-            await expect(soteriaCoverageProduct.connect(policyholder3).cancelPolicy(POLICY_ID_1)).to.revertedWith("!policyholder");
-        });
+    //     it("cannot cancel someone's policy", async () => {
+    //         await expect(soteriaCoverageProduct.connect(policyholder3).cancelPolicy(POLICY_ID_1)).to.revertedWith("!policyholder");
+    //     });
 
-        it("can cancel policy", async () => {
-            let policyholderBalance = await policyholder3.getBalance();
-            let policyCoverAmount = await soteriaCoverageProduct.connect(policyholder3).coverAmountOf(POLICY_ID_3);
-            let activeCoverAmount = await soteriaCoverageProduct.connect(policyholder3).activeCoverAmount();
-            let pmActiveCoverAmount = await policyManager.connect(policyholder3).activeCoverAmount();
-            let pmActiveCoverAmountForSoteria = await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
+    //     it("can cancel policy", async () => {
+    //         let policyholderBalance = await policyholder3.getBalance();
+    //         let policyCoverAmount = await soteriaCoverageProduct.connect(policyholder3).coverAmountOf(POLICY_ID_3);
+    //         let activeCoverAmount = await soteriaCoverageProduct.connect(policyholder3).activeCoverAmount();
+    //         let pmActiveCoverAmount = await policyManager.connect(policyholder3).activeCoverAmount();
+    //         let pmActiveCoverAmountForSoteria = await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
 
-            // cancel policy
-            let tx = await soteriaCoverageProduct.connect(policyholder3).cancelPolicy(POLICY_ID_3);
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyCanceled").withArgs(POLICY_ID_3);
+    //         // cancel policy
+    //         let tx = await soteriaCoverageProduct.connect(policyholder3).cancelPolicy(POLICY_ID_3);
+    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyCanceled").withArgs(POLICY_ID_3);
 
-            // user should get refunds
-            expect(await policyholder3.getBalance()).to.gte(policyholderBalance);
-            expect(await soteriaCoverageProduct.connect(policyholder3).funds(policyholder3.address)).to.equal(ZERO_AMOUNT);
+    //         // user should get refunds
+    //         expect(await policyholder3.getBalance()).to.gte(policyholderBalance);
+    //         expect(await soteriaCoverageProduct.connect(policyholder3).funds(policyholder3.address)).to.equal(ZERO_AMOUNT);
 
-            // soteria active cover amount should be decreased
-            expect(await soteriaCoverageProduct.connect(policyholder3).activeCoverAmount()).to.equal(activeCoverAmount.sub(policyCoverAmount));
+    //         // soteria active cover amount should be decreased
+    //         expect(await soteriaCoverageProduct.connect(policyholder3).activeCoverAmount()).to.equal(activeCoverAmount.sub(policyCoverAmount));
 
-            // cover limit should be zero
-            expect(await soteriaCoverageProduct.connect(policyholder3).coverAmountOf(POLICY_ID_3)).to.equal(ZERO_AMOUNT);
+    //         // cover limit should be zero
+    //         expect(await soteriaCoverageProduct.connect(policyholder3).coverAmountOf(POLICY_ID_3)).to.equal(ZERO_AMOUNT);
 
-            // policy status should be inactive
-            expect(await soteriaCoverageProduct.connect(policyholder3).policyStatus(POLICY_ID_3)).to.be.false;
+    //         // policy status should be inactive
+    //         expect(await soteriaCoverageProduct.connect(policyholder3).policyStatus(POLICY_ID_3)).to.be.false;
 
-            // policy manager active cover amount and active cover amount for soteria should be decreased
-            expect(await policyManager.connect(policyholder3).activeCoverAmount()).to.equal(pmActiveCoverAmount.sub(policyCoverAmount));
-            expect(await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(pmActiveCoverAmountForSoteria.sub(policyCoverAmount));
-        });
-    });
+    //         // policy manager active cover amount and active cover amount for soteria should be decreased
+    //         expect(await policyManager.connect(policyholder3).activeCoverAmount()).to.equal(pmActiveCoverAmount.sub(policyCoverAmount));
+    //         expect(await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(pmActiveCoverAmountForSoteria.sub(policyCoverAmount));
+    //     });
+    // });
 
-    describe("chargePremiums", () => {
-        it("cannot charge premiums by non-governance", async () => {
-            await expect(soteriaCoverageProduct.connect(policyholder1).chargePremiums([policyholder1.address, policyholder2.address], [PREMIUM_AMOUNT, PREMIUM_AMOUNT])).to.revertedWith("!governance");
-        });
+    // describe("chargePremiums", () => {
+    //     it("cannot charge premiums by non-governance", async () => {
+    //         await expect(soteriaCoverageProduct.connect(policyholder1).chargePremiums([policyholder1.address, policyholder2.address], [PREMIUM_AMOUNT, PREMIUM_AMOUNT])).to.revertedWith("!governance");
+    //     });
 
-        it("cannot charge premiums if argument lenghts are mismatched", async () => {
-            await expect(soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address, policyholder3.address], [PREMIUM_AMOUNT, PREMIUM_AMOUNT])).to.revertedWith("length mismatch");
-        });
+    //     it("cannot charge premiums if argument lenghts are mismatched", async () => {
+    //         await expect(soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address, policyholder3.address], [PREMIUM_AMOUNT, PREMIUM_AMOUNT])).to.revertedWith("length mismatch");
+    //     });
 
-        it("cannot charge premiums if policy count is exceeded", async () => {
-            await expect(soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address, policyholder3.address, policyholder4.address], [PREMIUM_AMOUNT, PREMIUM_AMOUNT, PREMIUM_AMOUNT, PREMIUM_AMOUNT])).to.revertedWith("policy count exceeded");
-        });
+    //     it("cannot charge premiums if policy count is exceeded", async () => {
+    //         await expect(soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address, policyholder3.address, policyholder4.address], [PREMIUM_AMOUNT, PREMIUM_AMOUNT, PREMIUM_AMOUNT, PREMIUM_AMOUNT])).to.revertedWith("policy count exceeded");
+    //     });
 
-        it("can charge premiums", async () => {
-            // premiums are routed to the vault in treasury!
-            let soteriaBalance = await provider.getBalance(soteriaCoverageProduct.address);
-            let vaultBalance = await provider.getBalance(vault.address);
-            let holderFunds = await soteriaCoverageProduct.connect(policyholder1).funds(policyholder1.address);
+    //     it("can charge premiums", async () => {
+    //         // premiums are routed to the vault in treasury!
+    //         let soteriaBalance = await provider.getBalance(soteriaCoverageProduct.address);
+    //         let vaultBalance = await provider.getBalance(vault.address);
+    //         let holderFunds = await soteriaCoverageProduct.connect(policyholder1).funds(policyholder1.address);
 
-            // charge premiums
-            let tx = soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address], [PREMIUM_AMOUNT]);
-            await expect(tx).emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder1.address, PREMIUM_AMOUNT);
+    //         // charge premiums
+    //         let tx = soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address], [PREMIUM_AMOUNT]);
+    //         await expect(tx).emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder1.address, PREMIUM_AMOUNT);
          
-            // funds should be decreased
-            expect(await soteriaCoverageProduct.connect(policyholder1).funds(policyholder1.address)).to.equal(holderFunds.sub(PREMIUM_AMOUNT));
-            // soteria balance should be decreased
-            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaBalance.sub(PREMIUM_AMOUNT));
-            // premium should be sent to treasury
-            expect(await provider.getBalance(vault.address)).to.equal(vaultBalance.add(PREMIUM_AMOUNT));
-        });
+    //         // funds should be decreased
+    //         expect(await soteriaCoverageProduct.connect(policyholder1).funds(policyholder1.address)).to.equal(holderFunds.sub(PREMIUM_AMOUNT));
+    //         // soteria balance should be decreased
+    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaBalance.sub(PREMIUM_AMOUNT));
+    //         // premium should be sent to treasury
+    //         expect(await provider.getBalance(vault.address)).to.equal(vaultBalance.add(PREMIUM_AMOUNT));
+    //     });
 
-        it("can partially charge premiums if the fund is insufficient", async () => {
-            // buy  new policy with 0.1 eth funding
-            let fundingAmount = PREMIUM_AMOUNT;
-            let tx = await soteriaCoverageProduct.connect(policyholder4).activatePolicy(policyholder4.address, COVER_AMOUNT, PREMIUM_AMOUNT, {value: fundingAmount});
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyCreated").withArgs(POLICY_ID_4);
+    //     it("can partially charge premiums if the fund is insufficient", async () => {
+    //         // buy  new policy with 0.1 eth funding
+    //         let fundingAmount = PREMIUM_AMOUNT;
+    //         let tx = await soteriaCoverageProduct.connect(policyholder4).activatePolicy(policyholder4.address, COVER_AMOUNT, PREMIUM_AMOUNT, {value: fundingAmount});
+    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyCreated").withArgs(POLICY_ID_4);
 
-            // premiums are routed to the vault in treasury!
-            let soteriaBalance = await provider.getBalance(soteriaCoverageProduct.address);
-            let vaultBalance = await provider.getBalance(vault.address);
-            let holderFunds = await soteriaCoverageProduct.connect(policyholder4).funds(policyholder4.address);
-            let activeCoverAmount = await soteriaCoverageProduct.connect(policyholder4).activeCoverAmount();
-            let policyCoverAmount = await soteriaCoverageProduct.connect(policyholder4).coverAmountOf(POLICY_ID_4);
-            let pmCoverAmount = await policyManager.connect(policyholder4).activeCoverAmount();
-            let pmSoteriaCoverAmount = await policyManager.connect(policyholder4).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
+    //         // premiums are routed to the vault in treasury!
+    //         let soteriaBalance = await provider.getBalance(soteriaCoverageProduct.address);
+    //         let vaultBalance = await provider.getBalance(vault.address);
+    //         let holderFunds = await soteriaCoverageProduct.connect(policyholder4).funds(policyholder4.address);
+    //         let activeCoverAmount = await soteriaCoverageProduct.connect(policyholder4).activeCoverAmount();
+    //         let policyCoverAmount = await soteriaCoverageProduct.connect(policyholder4).coverAmountOf(POLICY_ID_4);
+    //         let pmCoverAmount = await policyManager.connect(policyholder4).activeCoverAmount();
+    //         let pmSoteriaCoverAmount = await policyManager.connect(policyholder4).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
 
-            // charge premiums
-            tx = await soteriaCoverageProduct.connect(governor).chargePremiums([policyholder4.address], [PREMIUM_AMOUNT.mul(2)]);
-            await expect(tx).emit(soteriaCoverageProduct, "PremiumPartiallyCharged").withArgs(policyholder4.address, PREMIUM_AMOUNT.mul(2), fundingAmount);
+    //         // charge premiums
+    //         tx = await soteriaCoverageProduct.connect(governor).chargePremiums([policyholder4.address], [PREMIUM_AMOUNT.mul(2)]);
+    //         await expect(tx).emit(soteriaCoverageProduct, "PremiumPartiallyCharged").withArgs(policyholder4.address, PREMIUM_AMOUNT.mul(2), fundingAmount);
            
-            // policy should be closed
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyClosed").withArgs(POLICY_ID_4);
+    //         // policy should be closed
+    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyClosed").withArgs(POLICY_ID_4);
 
-            // active cover amount should be updated
-            expect(await soteriaCoverageProduct.connect(user).activeCoverAmount()).to.equal(activeCoverAmount.sub(policyCoverAmount));
+    //         // active cover amount should be updated
+    //         expect(await soteriaCoverageProduct.connect(user).activeCoverAmount()).to.equal(activeCoverAmount.sub(policyCoverAmount));
 
-            // policy's cover amount should be zero
-            expect(await soteriaCoverageProduct.connect(user).coverAmountOf(POLICY_ID_4)).to.equal(ZERO_AMOUNT);
+    //         // policy's cover amount should be zero
+    //         expect(await soteriaCoverageProduct.connect(user).coverAmountOf(POLICY_ID_4)).to.equal(ZERO_AMOUNT);
 
-            // policy manager should be updated
-            expect(await policyManager.connect(user).activeCoverAmount()).to.equal(pmCoverAmount.sub(policyCoverAmount));
-            expect(await policyManager.connect(user).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(pmSoteriaCoverAmount.sub(policyCoverAmount));
-            expect(await policyManager.connect(user).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(activeCoverAmount.sub(policyCoverAmount));
+    //         // policy manager should be updated
+    //         expect(await policyManager.connect(user).activeCoverAmount()).to.equal(pmCoverAmount.sub(policyCoverAmount));
+    //         expect(await policyManager.connect(user).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(pmSoteriaCoverAmount.sub(policyCoverAmount));
+    //         expect(await policyManager.connect(user).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(activeCoverAmount.sub(policyCoverAmount));
 
-            // policyholder funds should be zero
-            expect(await soteriaCoverageProduct.connect(user).funds(policyholder4.address)).to.equal(holderFunds.sub(fundingAmount));
-            expect(await soteriaCoverageProduct.connect(user).funds(policyholder4.address)).to.equal(ZERO_AMOUNT);
+    //         // policyholder funds should be zero
+    //         expect(await soteriaCoverageProduct.connect(user).funds(policyholder4.address)).to.equal(holderFunds.sub(fundingAmount));
+    //         expect(await soteriaCoverageProduct.connect(user).funds(policyholder4.address)).to.equal(ZERO_AMOUNT);
 
-            // soteria balance should be decreased
-            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaBalance.sub(fundingAmount));
+    //         // soteria balance should be decreased
+    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaBalance.sub(fundingAmount));
             
-            // premium should be sent to treasury
-            expect(await provider.getBalance(vault.address)).to.equal(vaultBalance.add(fundingAmount));
-        });
+    //         // premium should be sent to treasury
+    //         expect(await provider.getBalance(vault.address)).to.equal(vaultBalance.add(fundingAmount));
+    //     });
 
-        it("can charge premiums for only active policies", async () => {
-            // premiums are routed to the vault in treasury!
-            let soteriaBalance = await provider.getBalance(soteriaCoverageProduct.address);
-            let vaultBalance = await provider.getBalance(vault.address);
-            let holderFunds = await soteriaCoverageProduct.connect(policyholder2).funds(policyholder2.address);
+    //     it("can charge premiums for only active policies", async () => {
+    //         // premiums are routed to the vault in treasury!
+    //         let soteriaBalance = await provider.getBalance(soteriaCoverageProduct.address);
+    //         let vaultBalance = await provider.getBalance(vault.address);
+    //         let holderFunds = await soteriaCoverageProduct.connect(policyholder2).funds(policyholder2.address);
 
-            // charge premiums
-            let tx = soteriaCoverageProduct.connect(governor).chargePremiums([policyholder2.address, policyholder4.address], [PREMIUM_AMOUNT, PREMIUM_AMOUNT]);
-            await expect(tx).emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder2.address, PREMIUM_AMOUNT);
+    //         // charge premiums
+    //         let tx = soteriaCoverageProduct.connect(governor).chargePremiums([policyholder2.address, policyholder4.address], [PREMIUM_AMOUNT, PREMIUM_AMOUNT]);
+    //         await expect(tx).emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder2.address, PREMIUM_AMOUNT);
          
-            // funds should be decreased
-            expect(await soteriaCoverageProduct.connect(policyholder2).funds(policyholder2.address)).to.equal(holderFunds.sub(PREMIUM_AMOUNT));
+    //         // funds should be decreased
+    //         expect(await soteriaCoverageProduct.connect(policyholder2).funds(policyholder2.address)).to.equal(holderFunds.sub(PREMIUM_AMOUNT));
          
-            // soteria balance should be decreased
-            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaBalance.sub(PREMIUM_AMOUNT));
+    //         // soteria balance should be decreased
+    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaBalance.sub(PREMIUM_AMOUNT));
           
-            // premium should be sent to treasury
-            expect(await provider.getBalance(vault.address)).to.equal(vaultBalance.add(PREMIUM_AMOUNT));
-        });
-    });
-
-    describe("signers", function () {
-        it("non governance cannot add signers", async function () {
-          await expect(soteriaCoverageProduct.connect(policyholder1).addSigner(policyholder1.address)).to.be.revertedWith("!governance");
-        });
-    
-        it("cannot add zero signer", async function () {
-          await expect(soteriaCoverageProduct.connect(governor).addSigner(ZERO_ADDRESS)).to.be.revertedWith("zero address signer");
-        });
-    
-        it("can add signers", async function () {
-          expect(await soteriaCoverageProduct.isAuthorizedSigner(governor.address)).to.equal(false);
-          let tx = await soteriaCoverageProduct.connect(governor).addSigner(governor.address);
-          await expect(tx).to.emit(soteriaCoverageProduct, "SignerAdded").withArgs(governor.address);
-          expect(await soteriaCoverageProduct.isAuthorizedSigner(governor.address)).to.equal(true);
-        });
-    
-        it("non governance cannot remove signers", async function () {
-          await expect(soteriaCoverageProduct.connect(policyholder1).removeSigner(policyholder1.address)).to.be.revertedWith("!governance");
-        });
-    
-        it("can remove signers", async function () {
-          expect(await soteriaCoverageProduct.isAuthorizedSigner(governor.address)).to.equal(true);
-          let tx = await soteriaCoverageProduct.connect(governor).removeSigner(governor.address);
-          await expect(tx).to.emit(soteriaCoverageProduct, "SignerRemoved").withArgs(governor.address);
-          expect(await soteriaCoverageProduct.isAuthorizedSigner(governor.address)).to.equal(false);
-          await soteriaCoverageProduct.connect(governor).addSigner(governor.address);
-        });
-    });
+    //         // premium should be sent to treasury
+    //         expect(await provider.getBalance(vault.address)).to.equal(vaultBalance.add(PREMIUM_AMOUNT));
+    //     });
+    // });
 
 });

--- a/test/SoteriaCoverageProduct.test.ts
+++ b/test/SoteriaCoverageProduct.test.ts
@@ -276,706 +276,706 @@ describe("SoteriaCoverageProduct", function() {
         })
     })
 
-    describe("activatePolicy", () => {
-        let pmActiveCoverAmount:BN;
-        let pmSoteriaActiveCoverAmount: BN;
-        let mcr: BN;
-        let mcrps: BN;
+    // describe("activatePolicy", () => {
+    //     let pmActiveCoverAmount:BN;
+    //     let pmSoteriaActiveCoverAmount: BN;
+    //     let mcr: BN;
+    //     let mcrps: BN;
 
-        before(async () => {
-            // policy manager active cover amount and active cover amount for soteria.
-            await policyManager.connect(governor).setSoteriaProduct(soteriaCoverageProduct.address);
-            expect(await policyManager.connect(governor).getSoteriaProduct()).to.equal(soteriaCoverageProduct.address);
-            pmActiveCoverAmount = await policyManager.connect(governor).activeCoverAmount();
-            pmSoteriaActiveCoverAmount = await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
+    //     before(async () => {
+    //         // policy manager active cover amount and active cover amount for soteria.
+    //         await policyManager.connect(governor).setSoteriaProduct(soteriaCoverageProduct.address);
+    //         expect(await policyManager.connect(governor).getSoteriaProduct()).to.equal(soteriaCoverageProduct.address);
+    //         pmActiveCoverAmount = await policyManager.connect(governor).activeCoverAmount();
+    //         pmSoteriaActiveCoverAmount = await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
 
-            // risk manager min. capital requirement and min. capital requirement for soteria
-            mcr = await riskManager.connect(governor).minCapitalRequirement();
-            mcrps = await riskManager.connect(governor).minCapitalRequirementPerStrategy(soteriaCoverageProduct.address);
-        });
+    //         // risk manager min. capital requirement and min. capital requirement for soteria
+    //         mcr = await riskManager.connect(governor).minCapitalRequirement();
+    //         mcrps = await riskManager.connect(governor).minCapitalRequirementPerStrategy(soteriaCoverageProduct.address);
+    //     });
 
-        it("cannot activate policy when zero address policy holder is provided", async () => {
-            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(ZERO_ADDRESS, INITIAL_COVER_LIMIT)).to.revertedWith("zero address policyholder");
-        });
+    //     it("cannot activate policy when zero address policy holder is provided", async () => {
+    //         await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(ZERO_ADDRESS, INITIAL_COVER_LIMIT)).to.revertedWith("zero address policyholder");
+    //     });
 
-        it("cannot buy policy when zero cover amount value is provided", async () => {
-            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, ZERO_AMOUNT)).to.revertedWith("zero cover value");
-        });
+    //     it("cannot buy policy when zero cover amount value is provided", async () => {
+    //         await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, ZERO_AMOUNT)).to.revertedWith("zero cover value");
+    //     });
 
-        it("cannot buy policy when contract is paused", async () => {
-            await soteriaCoverageProduct.connect(governor).setPaused(true);
-            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, INITIAL_COVER_LIMIT, {value: ONE_ETH})).to.revertedWith("contract paused");
-            await soteriaCoverageProduct.connect(governor).setPaused(false);
-        });
+    //     it("cannot buy policy when contract is paused", async () => {
+    //         await soteriaCoverageProduct.connect(governor).setPaused(true);
+    //         await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, INITIAL_COVER_LIMIT, {value: ONE_ETH})).to.revertedWith("contract paused");
+    //         await soteriaCoverageProduct.connect(governor).setPaused(false);
+    //     });
 
-        it("can cannot purchase a policy before Coverage Data Provider and Risk Manager are set up (maxCover = 0)", async () => {
-            expect (await soteriaCoverageProduct.maxCover()).eq(0)
-            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, INITIAL_COVER_LIMIT, {value: ZERO_AMOUNT})).to.revertedWith("insufficient capacity for new cover");
-        })
+    //     it("can cannot purchase a policy before Coverage Data Provider and Risk Manager are set up (maxCover = 0)", async () => {
+    //         expect (await soteriaCoverageProduct.maxCover()).eq(0)
+    //         await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, INITIAL_COVER_LIMIT, {value: ZERO_AMOUNT})).to.revertedWith("insufficient capacity for new cover");
+    //     })
 
-        it("can setup Coverage Data Provider and Risk Manager", async () => {
-            // add underwriting pool to the coverage data provider
-            let maxCover1 = await riskManager.connect(governor).maxCover();
-            expect(maxCover1).to.equal(0)
-            expect(await coverageDataProvider.connect(governor).numOfPools()).to.equal(0);
+    //     it("can setup Coverage Data Provider and Risk Manager", async () => {
+    //         // add underwriting pool to the coverage data provider
+    //         let maxCover1 = await riskManager.connect(governor).maxCover();
+    //         expect(maxCover1).to.equal(0)
+    //         expect(await coverageDataProvider.connect(governor).numOfPools()).to.equal(0);
 
-            await coverageDataProvider.connect(governor).addPools([underwritingPool.address]);
-            expect(await coverageDataProvider.connect(governor).numOfPools()).to.equal(1);
-            let uwpETHBalance = await underwritingPool.getBalance();
-            let maxCover2 = await riskManager.connect(governor).maxCover();
-            expect(maxCover2).to.equal(maxCover1.add(uwpETHBalance));
+    //         await coverageDataProvider.connect(governor).addPools([underwritingPool.address]);
+    //         expect(await coverageDataProvider.connect(governor).numOfPools()).to.equal(1);
+    //         let uwpETHBalance = await underwritingPool.getBalance();
+    //         let maxCover2 = await riskManager.connect(governor).maxCover();
+    //         expect(maxCover2).to.equal(maxCover1.add(uwpETHBalance));
             
-            // add Soteria to the risk manager and assign coverage allocation
-            await riskManager.connect(governor).addRiskStrategy(soteriaCoverageProduct.address);
-            await riskManager.connect(governor).setStrategyStatus(soteriaCoverageProduct.address, STRATEGY_STATUS.ACTIVE);
-            await riskManager.connect(governor).setWeightAllocation(soteriaCoverageProduct.address, 1000);
-            expect(await riskManager.connect(governor).maxCoverPerStrategy(soteriaCoverageProduct.address)).to.equal(maxCover2);
-            expect(await riskManager.connect(governor).maxCoverPerStrategy(soteriaCoverageProduct.address)).to.equal(await soteriaCoverageProduct.maxCover());
-        })
+    //         // add Soteria to the risk manager and assign coverage allocation
+    //         await riskManager.connect(governor).addRiskStrategy(soteriaCoverageProduct.address);
+    //         await riskManager.connect(governor).setStrategyStatus(soteriaCoverageProduct.address, STRATEGY_STATUS.ACTIVE);
+    //         await riskManager.connect(governor).setWeightAllocation(soteriaCoverageProduct.address, 1000);
+    //         expect(await riskManager.connect(governor).maxCoverPerStrategy(soteriaCoverageProduct.address)).to.equal(maxCover2);
+    //         expect(await riskManager.connect(governor).maxCoverPerStrategy(soteriaCoverageProduct.address)).to.equal(await soteriaCoverageProduct.maxCover());
+    //     })
 
-        it("cannot buy policy when max cover exceeded", async () => {
-            let maxCover = await soteriaCoverageProduct.maxCover();
-            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, maxCover.add(1), {value: ONE_ETH})).to.revertedWith("insufficient capacity for new cover");
-        });
+    //     it("cannot buy policy when max cover exceeded", async () => {
+    //         let maxCover = await soteriaCoverageProduct.maxCover();
+    //         await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, maxCover.add(1), {value: ONE_ETH})).to.revertedWith("insufficient capacity for new cover");
+    //     });
 
-        it("cannot buy policy when insufficient deposit provided", async () => {
-            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, ONE_ETH, {value: ZERO_AMOUNT})).to.revertedWith("insufficient deposit for minimum required account balance");
-        });
+    //     it("cannot buy policy when insufficient deposit provided", async () => {
+    //         await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, ONE_ETH, {value: ZERO_AMOUNT})).to.revertedWith("insufficient deposit for minimum required account balance");
+    //     });
 
-        it("can activate policy - 1 ETH cover with 1 ETH deposit", async () => {
-            let tx = await soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, ONE_ETH, {value: ONE_ETH});
+    //     it("can activate policy - 1 ETH cover with 1 ETH deposit", async () => {
+    //         let tx = await soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, ONE_ETH, {value: ONE_ETH});
 
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyCreated").withArgs(POLICY_ID_1);
-            await expect(tx).emit(soteriaCoverageProduct, "Transfer").withArgs(ZERO_ADDRESS, policyholder1.address, POLICY_ID_1);
+    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyCreated").withArgs(POLICY_ID_1);
+    //         await expect(tx).emit(soteriaCoverageProduct, "Transfer").withArgs(ZERO_ADDRESS, policyholder1.address, POLICY_ID_1);
 
-            expect (await soteriaCoverageProduct.rewardPointsOf(policyholder1.address)).eq(0)
-            expect (await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).eq(ONE_ETH)
-            expect (await soteriaCoverageProduct.policyStatus(POLICY_ID_1)).eq(true)
-            expect (await soteriaCoverageProduct.policyOf(policyholder1.address)).eq(POLICY_ID_1)
-            expect (await soteriaCoverageProduct.ownerOf(POLICY_ID_1)).eq(policyholder1.address)
-            expect (await soteriaCoverageProduct.activeCoverLimit()).eq(ONE_ETH)
-            expect (await soteriaCoverageProduct.policyCount()).eq(1)
-            expect (await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1)).eq(ONE_ETH)
-            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(ONE_ETH);
-        });
+    //         expect (await soteriaCoverageProduct.rewardPointsOf(policyholder1.address)).eq(0)
+    //         expect (await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).eq(ONE_ETH)
+    //         expect (await soteriaCoverageProduct.policyStatus(POLICY_ID_1)).eq(true)
+    //         expect (await soteriaCoverageProduct.policyOf(policyholder1.address)).eq(POLICY_ID_1)
+    //         expect (await soteriaCoverageProduct.ownerOf(POLICY_ID_1)).eq(policyholder1.address)
+    //         expect (await soteriaCoverageProduct.activeCoverLimit()).eq(ONE_ETH)
+    //         expect (await soteriaCoverageProduct.policyCount()).eq(1)
+    //         expect (await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1)).eq(ONE_ETH)
+    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(ONE_ETH);
+    //     });
 
-        it("cannot purchase more than one policy for a single address", async () => {
-            await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, ONE_ETH, {value: ONE_ETH})).to.be.revertedWith("policy already activated")
-            await expect(soteriaCoverageProduct.connect(policyholder2).activatePolicy(policyholder1.address, ONE_ETH, {value: ONE_ETH})).to.be.revertedWith("policy already activated")
-        })
+    //     it("cannot purchase more than one policy for a single address", async () => {
+    //         await expect(soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, ONE_ETH, {value: ONE_ETH})).to.be.revertedWith("policy already activated")
+    //         await expect(soteriaCoverageProduct.connect(policyholder2).activatePolicy(policyholder1.address, ONE_ETH, {value: ONE_ETH})).to.be.revertedWith("policy already activated")
+    //     })
         
-        it("cannot transfer policy", async () => {
-            await expect(soteriaCoverageProduct.connect(policyholder1).transferFrom(policyholder1.address, policyholder2.address, 1)).to.be.revertedWith("only minting permitted");
-            await expect(soteriaCoverageProduct.connect(policyholder1).transferFrom(policyholder1.address, ZERO_ADDRESS, 1)).to.be.revertedWith("ERC721: transfer to the zero address");
-            // TO-DO, test ERC721.safeTransferFrom() => TypeError: soteriaCoverageProduct.connect(...).safeTransferFrom is not a function
-        })
+    //     it("cannot transfer policy", async () => {
+    //         await expect(soteriaCoverageProduct.connect(policyholder1).transferFrom(policyholder1.address, policyholder2.address, 1)).to.be.revertedWith("only minting permitted");
+    //         await expect(soteriaCoverageProduct.connect(policyholder1).transferFrom(policyholder1.address, ZERO_ADDRESS, 1)).to.be.revertedWith("ERC721: transfer to the zero address");
+    //         // TO-DO, test ERC721.safeTransferFrom() => TypeError: soteriaCoverageProduct.connect(...).safeTransferFrom is not a function
+    //     })
 
-        it("can activate policy for another address - 1 ETH cover with 1 ETH deposit", async () => {
-            let tx = await soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder2.address, ONE_ETH, {value: ONE_ETH});
+    //     it("can activate policy for another address - 1 ETH cover with 1 ETH deposit", async () => {
+    //         let tx = await soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder2.address, ONE_ETH, {value: ONE_ETH});
 
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyCreated").withArgs(POLICY_ID_2);
-            await expect(tx).emit(soteriaCoverageProduct, "Transfer").withArgs(ZERO_ADDRESS, policyholder2.address, POLICY_ID_2);
+    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyCreated").withArgs(POLICY_ID_2);
+    //         await expect(tx).emit(soteriaCoverageProduct, "Transfer").withArgs(ZERO_ADDRESS, policyholder2.address, POLICY_ID_2);
 
-            expect (await soteriaCoverageProduct.rewardPointsOf(policyholder2.address)).eq(0)
-            expect (await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).eq(ONE_ETH)
-            expect (await soteriaCoverageProduct.accountBalanceOf(policyholder2.address)).eq(ONE_ETH)
-            expect (await soteriaCoverageProduct.policyStatus(POLICY_ID_2)).eq(true)
-            expect (await soteriaCoverageProduct.policyOf(policyholder2.address)).eq(POLICY_ID_2)
-            expect (await soteriaCoverageProduct.ownerOf(POLICY_ID_2)).eq(policyholder2.address)
-            expect (await soteriaCoverageProduct.activeCoverLimit()).eq(ONE_ETH.mul(2))
-            expect (await soteriaCoverageProduct.policyCount()).eq(2)
-            expect (await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2)).eq(ONE_ETH)
-            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(ONE_ETH.mul(2));
-        });
-        it("policy holder should have policy nft after buying coverage", async () => {
-            expect(await soteriaCoverageProduct.connect(policyholder1).balanceOf(policyholder1.address)).to.equal(1);
-            expect(await soteriaCoverageProduct.connect(policyholder2).balanceOf(policyholder2.address)).to.equal(1);
-        });
-        it("should update policy manager active cover amount", async () => {
-            let activeCoverLimit = await soteriaCoverageProduct.activeCoverLimit();
-            expect(await policyManager.connect(governor).activeCoverAmount()).to.equal(pmActiveCoverAmount.add(activeCoverLimit));
-            expect(await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(pmSoteriaActiveCoverAmount.add(activeCoverLimit));
-        });
-        it("should update risk manager mcr", async () => {
-            let activeCoverLimit = await soteriaCoverageProduct.connect(governor).activeCoverLimit();
-            expect(await riskManager.connect(governor).minCapitalRequirement()).to.equal(mcr.add(activeCoverLimit));
-            expect(await riskManager.connect(governor).minCapitalRequirementPerStrategy(soteriaCoverageProduct.address)).to.equal(mcrps.add(activeCoverLimit));
-        });
-    });
+    //         expect (await soteriaCoverageProduct.rewardPointsOf(policyholder2.address)).eq(0)
+    //         expect (await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).eq(ONE_ETH)
+    //         expect (await soteriaCoverageProduct.accountBalanceOf(policyholder2.address)).eq(ONE_ETH)
+    //         expect (await soteriaCoverageProduct.policyStatus(POLICY_ID_2)).eq(true)
+    //         expect (await soteriaCoverageProduct.policyOf(policyholder2.address)).eq(POLICY_ID_2)
+    //         expect (await soteriaCoverageProduct.ownerOf(POLICY_ID_2)).eq(policyholder2.address)
+    //         expect (await soteriaCoverageProduct.activeCoverLimit()).eq(ONE_ETH.mul(2))
+    //         expect (await soteriaCoverageProduct.policyCount()).eq(2)
+    //         expect (await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2)).eq(ONE_ETH)
+    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(ONE_ETH.mul(2));
+    //     });
+    //     it("policy holder should have policy nft after buying coverage", async () => {
+    //         expect(await soteriaCoverageProduct.connect(policyholder1).balanceOf(policyholder1.address)).to.equal(1);
+    //         expect(await soteriaCoverageProduct.connect(policyholder2).balanceOf(policyholder2.address)).to.equal(1);
+    //     });
+    //     it("should update policy manager active cover amount", async () => {
+    //         let activeCoverLimit = await soteriaCoverageProduct.activeCoverLimit();
+    //         expect(await policyManager.connect(governor).activeCoverAmount()).to.equal(pmActiveCoverAmount.add(activeCoverLimit));
+    //         expect(await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(pmSoteriaActiveCoverAmount.add(activeCoverLimit));
+    //     });
+    //     it("should update risk manager mcr", async () => {
+    //         let activeCoverLimit = await soteriaCoverageProduct.connect(governor).activeCoverLimit();
+    //         expect(await riskManager.connect(governor).minCapitalRequirement()).to.equal(mcr.add(activeCoverLimit));
+    //         expect(await riskManager.connect(governor).minCapitalRequirementPerStrategy(soteriaCoverageProduct.address)).to.equal(mcrps.add(activeCoverLimit));
+    //     });
+    // });
 
-    describe("deposit", () => {
-        it("can deposit", async () => {
-            let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
-            let soteriaContractETHbalance = await provider.getBalance(soteriaCoverageProduct.address);
-            let tx = await soteriaCoverageProduct.connect(policyholder1).deposit(policyholder1.address, { value: ONE_ETH });
-            await expect(tx).emit(soteriaCoverageProduct, "DepositMade").withArgs(policyholder1.address, ONE_ETH);
-            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(accountBalance.add(ONE_ETH));
-            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaContractETHbalance.add(ONE_ETH));
-        });
+    // describe("deposit", () => {
+    //     it("can deposit", async () => {
+    //         let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
+    //         let soteriaContractETHbalance = await provider.getBalance(soteriaCoverageProduct.address);
+    //         let tx = await soteriaCoverageProduct.connect(policyholder1).deposit(policyholder1.address, { value: ONE_ETH });
+    //         await expect(tx).emit(soteriaCoverageProduct, "DepositMade").withArgs(policyholder1.address, ONE_ETH);
+    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(accountBalance.add(ONE_ETH));
+    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaContractETHbalance.add(ONE_ETH));
+    //     });
 
-        it("can deposit on behalf of policy holder", async () => {
-            let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder2.address);
-            let soteriaContractETHbalance = await provider.getBalance(soteriaCoverageProduct.address);
-            let tx = await soteriaCoverageProduct.connect(policyholder1).deposit(policyholder2.address, { value: ONE_ETH });
-            await expect(tx).emit(soteriaCoverageProduct, "DepositMade").withArgs(policyholder2.address, ONE_ETH);
-            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder2.address)).to.equal(accountBalance.add(ONE_ETH));
-            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaContractETHbalance.add(ONE_ETH));
-        });
+    //     it("can deposit on behalf of policy holder", async () => {
+    //         let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder2.address);
+    //         let soteriaContractETHbalance = await provider.getBalance(soteriaCoverageProduct.address);
+    //         let tx = await soteriaCoverageProduct.connect(policyholder1).deposit(policyholder2.address, { value: ONE_ETH });
+    //         await expect(tx).emit(soteriaCoverageProduct, "DepositMade").withArgs(policyholder2.address, ONE_ETH);
+    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder2.address)).to.equal(accountBalance.add(ONE_ETH));
+    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaContractETHbalance.add(ONE_ETH));
+    //     });
 
-        it("can deposit via fallback", async () => {
-            let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder2.address);
-            let soteriaContractETHbalance = await provider.getBalance(soteriaCoverageProduct.address);
-            let tx = await policyholder1.sendTransaction({ to: soteriaCoverageProduct.address, value: ONE_ETH });
-            await expect(tx).emit(soteriaCoverageProduct, "DepositMade").withArgs(policyholder1.address, ONE_ETH);
-            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(accountBalance.add(ONE_ETH));
-            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaContractETHbalance.add(ONE_ETH));
-        });
+    //     it("can deposit via fallback", async () => {
+    //         let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder2.address);
+    //         let soteriaContractETHbalance = await provider.getBalance(soteriaCoverageProduct.address);
+    //         let tx = await policyholder1.sendTransaction({ to: soteriaCoverageProduct.address, value: ONE_ETH });
+    //         await expect(tx).emit(soteriaCoverageProduct, "DepositMade").withArgs(policyholder1.address, ONE_ETH);
+    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(accountBalance.add(ONE_ETH));
+    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaContractETHbalance.add(ONE_ETH));
+    //     });
 
-        it("can deposit via receive", async () => {
-            let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
-            let soteriaContractETHbalance = await provider.getBalance(soteriaCoverageProduct.address);
-            let tx = await policyholder1.sendTransaction({ to: soteriaCoverageProduct.address, value: ONE_ETH, data:"0x00"});
-            await expect(tx).emit(soteriaCoverageProduct, "DepositMade").withArgs(policyholder1.address, ONE_ETH);
-            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(accountBalance.add(ONE_ETH));
-            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaContractETHbalance.add(ONE_ETH));
-        });
+    //     it("can deposit via receive", async () => {
+    //         let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
+    //         let soteriaContractETHbalance = await provider.getBalance(soteriaCoverageProduct.address);
+    //         let tx = await policyholder1.sendTransaction({ to: soteriaCoverageProduct.address, value: ONE_ETH, data:"0x00"});
+    //         await expect(tx).emit(soteriaCoverageProduct, "DepositMade").withArgs(policyholder1.address, ONE_ETH);
+    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(accountBalance.add(ONE_ETH));
+    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaContractETHbalance.add(ONE_ETH));
+    //     });
 
-        it("cannot deposit while paused", async () => {
-            await soteriaCoverageProduct.connect(governor).setPaused(true);
-            await expect(soteriaCoverageProduct.connect(policyholder1).deposit(policyholder1.address, { value: ONE_ETH })).to.revertedWith("contract paused");
-            await soteriaCoverageProduct.connect(governor).setPaused(false);
-        });
-    });
+    //     it("cannot deposit while paused", async () => {
+    //         await soteriaCoverageProduct.connect(governor).setPaused(true);
+    //         await expect(soteriaCoverageProduct.connect(policyholder1).deposit(policyholder1.address, { value: ONE_ETH })).to.revertedWith("contract paused");
+    //         await soteriaCoverageProduct.connect(governor).setPaused(false);
+    //     });
+    // });
 
-    describe("withdraw", () => {
-        let initialAccountBalance: BN;
-        let initialPolicyCover:BN;
+    // describe("withdraw", () => {
+    //     let initialAccountBalance: BN;
+    //     let initialPolicyCover:BN;
 
-        before(async () => {
-            initialAccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
-            initialPolicyCover = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1);
-        })
+    //     before(async () => {
+    //         initialAccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
+    //         initialPolicyCover = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1);
+    //     })
         
-        it("cannot withdraw while paused", async () => {
-            await soteriaCoverageProduct.connect(governor).setPaused(true);
-            await expect(soteriaCoverageProduct.connect(policyholder1).withdraw(ONE_ETH)).to.revertedWith("contract paused");
-            await soteriaCoverageProduct.connect(governor).setPaused(false);
-        });
-        it("cannot withdraw more than account balance", async () => {
-            let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
-            await expect(soteriaCoverageProduct.connect(policyholder1).withdraw(accountBalance.add(1))).to.revertedWith("cannot withdraw this amount");
-        })
-        it("can withdraw", async () => {
-            let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
-            let policyholderETHBalance = await provider.getBalance(policyholder1.address)
-            let soteriaETHBalance = await provider.getBalance(soteriaCoverageProduct.address)
+    //     it("cannot withdraw while paused", async () => {
+    //         await soteriaCoverageProduct.connect(governor).setPaused(true);
+    //         await expect(soteriaCoverageProduct.connect(policyholder1).withdraw(ONE_ETH)).to.revertedWith("contract paused");
+    //         await soteriaCoverageProduct.connect(governor).setPaused(false);
+    //     });
+    //     it("cannot withdraw more than account balance", async () => {
+    //         let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
+    //         await expect(soteriaCoverageProduct.connect(policyholder1).withdraw(accountBalance.add(1))).to.revertedWith("cannot withdraw this amount");
+    //     })
+    //     it("can withdraw", async () => {
+    //         let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
+    //         let policyholderETHBalance = await provider.getBalance(policyholder1.address)
+    //         let soteriaETHBalance = await provider.getBalance(soteriaCoverageProduct.address)
             
-            let tx = await soteriaCoverageProduct.connect(policyholder1).withdraw(ONE_ETH);
+    //         let tx = await soteriaCoverageProduct.connect(policyholder1).withdraw(ONE_ETH);
             
-            let receipt = await tx.wait();
-            let gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice);
-            await expect(tx).emit(soteriaCoverageProduct, "WithdrawMade").withArgs(policyholder1.address, ONE_ETH);
-            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(accountBalance.sub(ONE_ETH));
-            expect(await provider.getBalance(policyholder1.address)).eq(policyholderETHBalance.add(ONE_ETH).sub(gasCost))
-            expect(await provider.getBalance(soteriaCoverageProduct.address)).eq(soteriaETHBalance.sub(ONE_ETH))
-        })
-        it("will deactivate policy if withdraw below minimum permitted account balance", async () => {
-            let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
-            let policyholderETHBalance = await provider.getBalance(policyholder1.address)
-            let soteriaETHBalance = await provider.getBalance(soteriaCoverageProduct.address)
-            let policyCoverLimit = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1);
-            let activeCoverLimit = await soteriaCoverageProduct.activeCoverLimit();
+    //         let receipt = await tx.wait();
+    //         let gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice);
+    //         await expect(tx).emit(soteriaCoverageProduct, "WithdrawMade").withArgs(policyholder1.address, ONE_ETH);
+    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(accountBalance.sub(ONE_ETH));
+    //         expect(await provider.getBalance(policyholder1.address)).eq(policyholderETHBalance.add(ONE_ETH).sub(gasCost))
+    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).eq(soteriaETHBalance.sub(ONE_ETH))
+    //     })
+    //     it("will deactivate policy if withdraw below minimum permitted account balance", async () => {
+    //         let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
+    //         let policyholderETHBalance = await provider.getBalance(policyholder1.address)
+    //         let soteriaETHBalance = await provider.getBalance(soteriaCoverageProduct.address)
+    //         let policyCoverLimit = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1);
+    //         let activeCoverLimit = await soteriaCoverageProduct.activeCoverLimit();
 
-            let tx = await soteriaCoverageProduct.connect(policyholder1).withdraw(accountBalance.sub(1));
+    //         let tx = await soteriaCoverageProduct.connect(policyholder1).withdraw(accountBalance.sub(1));
 
-            let receipt = await tx.wait();
-            let gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice);
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyDeactivated").withArgs(POLICY_ID_1);
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(activeCoverLimit.sub(policyCoverLimit));
-            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(0);
-            expect(await provider.getBalance(policyholder1.address)).eq(policyholderETHBalance.add(accountBalance).sub(gasCost))
-            expect(await provider.getBalance(soteriaCoverageProduct.address)).eq(soteriaETHBalance.sub(accountBalance))
-            expect (await soteriaCoverageProduct.policyStatus(POLICY_ID_1)).eq(false)
-            expect (await soteriaCoverageProduct.ownerOf(POLICY_ID_1)).eq(policyholder1.address)
-            expect (await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1)).eq(0)
-            expect (await soteriaCoverageProduct.activeCoverLimit()).eq(activeCoverLimit.sub(policyCoverLimit))
-            expect (await soteriaCoverageProduct.policyCount()).eq(2)
-        })
-        after(async () => {
-            let tx = await soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, initialPolicyCover, {value: initialPolicyCover})
-            let tx2 = await policyholder1.sendTransaction({ to: soteriaCoverageProduct.address, value: initialAccountBalance.sub(initialPolicyCover)});
-            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).eq(initialAccountBalance);
-            expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1)).eq(initialPolicyCover)
-            expect (await soteriaCoverageProduct.policyStatus(POLICY_ID_1)).eq(true)
-        })
-    });
+    //         let receipt = await tx.wait();
+    //         let gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice);
+    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyDeactivated").withArgs(POLICY_ID_1);
+    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(activeCoverLimit.sub(policyCoverLimit));
+    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(0);
+    //         expect(await provider.getBalance(policyholder1.address)).eq(policyholderETHBalance.add(accountBalance).sub(gasCost))
+    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).eq(soteriaETHBalance.sub(accountBalance))
+    //         expect (await soteriaCoverageProduct.policyStatus(POLICY_ID_1)).eq(false)
+    //         expect (await soteriaCoverageProduct.ownerOf(POLICY_ID_1)).eq(policyholder1.address)
+    //         expect (await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1)).eq(0)
+    //         expect (await soteriaCoverageProduct.activeCoverLimit()).eq(activeCoverLimit.sub(policyCoverLimit))
+    //         expect (await soteriaCoverageProduct.policyCount()).eq(2)
+    //     })
+    //     after(async () => {
+    //         let tx = await soteriaCoverageProduct.connect(policyholder1).activatePolicy(policyholder1.address, initialPolicyCover, {value: initialPolicyCover})
+    //         let tx2 = await policyholder1.sendTransaction({ to: soteriaCoverageProduct.address, value: initialAccountBalance.sub(initialPolicyCover)});
+    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).eq(initialAccountBalance);
+    //         expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1)).eq(initialPolicyCover)
+    //         expect (await soteriaCoverageProduct.policyStatus(POLICY_ID_1)).eq(true)
+    //     })
+    // });
 
-    describe("updateCoverAmount", () => {
-        let maxCover: BN;
-        let maxCoverPerStrategy: BN;
-        let initialMCRForSoteria: BN;
-        let initialMCR: BN; // min. capital requirement
-        let initialSoteriaActiveCoverLimit: BN;
-        let initialPolicyCoverLimit: BN;
-        let initialPMActiveCoverLimit: BN; // policy manager active cover amount
-        let initialPMActiveCoverLimitForSoteria: BN; // policy manager active cover amount for soteria
+    // describe("updateCoverAmount", () => {
+    //     let maxCover: BN;
+    //     let maxCoverPerStrategy: BN;
+    //     let initialMCRForSoteria: BN;
+    //     let initialMCR: BN; // min. capital requirement
+    //     let initialSoteriaActiveCoverLimit: BN;
+    //     let initialPolicyCoverLimit: BN;
+    //     let initialPMActiveCoverLimit: BN; // policy manager active cover amount
+    //     let initialPMActiveCoverLimitForSoteria: BN; // policy manager active cover amount for soteria
 
-        before(async () => {
-            maxCover = await riskManager.connect(governor).maxCover();
-            maxCoverPerStrategy = await riskManager.connect(governor).maxCoverPerStrategy(soteriaCoverageProduct.address);
+    //     before(async () => {
+    //         maxCover = await riskManager.connect(governor).maxCover();
+    //         maxCoverPerStrategy = await riskManager.connect(governor).maxCoverPerStrategy(soteriaCoverageProduct.address);
 
-            // risk manager current values
-            initialMCR = await riskManager.connect(governor).minCapitalRequirement();
-            initialMCRForSoteria = await riskManager.connect(governor).minCapitalRequirementPerStrategy(soteriaCoverageProduct.address);
+    //         // risk manager current values
+    //         initialMCR = await riskManager.connect(governor).minCapitalRequirement();
+    //         initialMCRForSoteria = await riskManager.connect(governor).minCapitalRequirementPerStrategy(soteriaCoverageProduct.address);
             
-            // policy manager current values
-            initialPMActiveCoverLimit = await policyManager.connect(governor).activeCoverAmount();
-            initialPMActiveCoverLimitForSoteria = await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
+    //         // policy manager current values
+    //         initialPMActiveCoverLimit = await policyManager.connect(governor).activeCoverAmount();
+    //         initialPMActiveCoverLimitForSoteria = await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
 
-            initialSoteriaActiveCoverLimit = await soteriaCoverageProduct.connect(policyholder1).activeCoverLimit();
-            initialPolicyCoverLimit = await soteriaCoverageProduct.connect(policyholder1).coverLimitOf(POLICY_ID_1);
+    //         initialSoteriaActiveCoverLimit = await soteriaCoverageProduct.connect(policyholder1).activeCoverLimit();
+    //         initialPolicyCoverLimit = await soteriaCoverageProduct.connect(policyholder1).coverLimitOf(POLICY_ID_1);
 
-            expect(await soteriaCoverageProduct.connect(policyholder1).ownerOf(POLICY_ID_1)).to.equal(policyholder1.address);
-        });
+    //         expect(await soteriaCoverageProduct.connect(policyholder1).ownerOf(POLICY_ID_1)).to.equal(policyholder1.address);
+    //     });
 
-        it("cannot update for zero cover amount", async () => {
-            await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, ZERO_AMOUNT)).to.revertedWith("zero cover value");
-        });
+    //     it("cannot update for zero cover amount", async () => {
+    //         await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, ZERO_AMOUNT)).to.revertedWith("zero cover value");
+    //     });
 
-        it("cannot update for invalid policy", async () => {
-            await expect(soteriaCoverageProduct.connect(governor).updateCoverLimit(POLICY_ID_3, NEW_COVER_LIMIT)).to.revertedWith("invalid policy");
-        });
+    //     it("cannot update for invalid policy", async () => {
+    //         await expect(soteriaCoverageProduct.connect(governor).updateCoverLimit(POLICY_ID_3, NEW_COVER_LIMIT)).to.revertedWith("invalid policy");
+    //     });
 
-        it("cannot update while paused", async () => {
-            await soteriaCoverageProduct.connect(governor).setPaused(true);
-            await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, NEW_COVER_LIMIT)).to.revertedWith("contract paused");
-            await soteriaCoverageProduct.connect(governor).setPaused(false);
-        });
+    //     it("cannot update while paused", async () => {
+    //         await soteriaCoverageProduct.connect(governor).setPaused(true);
+    //         await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, NEW_COVER_LIMIT)).to.revertedWith("contract paused");
+    //         await soteriaCoverageProduct.connect(governor).setPaused(false);
+    //     });
 
-        it("cannot update if non-governance or not own policy", async () => {
-            await expect(soteriaCoverageProduct.connect(deployer).updateCoverLimit(POLICY_ID_1, NEW_COVER_LIMIT)).to.revertedWith("not owner or governance");
-        })
+    //     it("cannot update if non-governance or not own policy", async () => {
+    //         await expect(soteriaCoverageProduct.connect(deployer).updateCoverLimit(POLICY_ID_1, NEW_COVER_LIMIT)).to.revertedWith("not owner or governance");
+    //     })
 
-        it("cannot update if max cover is exceeded", async () => {
-            await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, maxCover.add(1))).to.revertedWith("insufficient capacity for new cover");
-        });
+    //     it("cannot update if max cover is exceeded", async () => {
+    //         await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, maxCover.add(1))).to.revertedWith("insufficient capacity for new cover");
+    //     });
 
-        it("cannot update if max cover for the strategy is exceeded", async () => {
-            await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, maxCoverPerStrategy.add(1))).to.revertedWith("insufficient capacity for new cover");
-        });
+    //     it("cannot update if max cover for the strategy is exceeded", async () => {
+    //         await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, maxCoverPerStrategy.add(1))).to.revertedWith("insufficient capacity for new cover");
+    //     });
 
-        it("cannot update if below minimum required account balance for newCoverLimit", async () => {
-            let maxRateNum = await soteriaCoverageProduct.maxRateNum();
-            let maxRateDenom = await soteriaCoverageProduct.maxRateDenom();
-            let chargeCycle = await soteriaCoverageProduct.chargeCycle();
-            let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)
-            let maxPermissibleNewCoverLimit = accountBalance.mul(maxRateDenom).div(maxRateNum).div(chargeCycle)
-            await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, maxPermissibleNewCoverLimit.add(ONE_ETH))).to.revertedWith("insufficient deposit for minimum required account balance");
-        })
+    //     it("cannot update if below minimum required account balance for newCoverLimit", async () => {
+    //         let maxRateNum = await soteriaCoverageProduct.maxRateNum();
+    //         let maxRateDenom = await soteriaCoverageProduct.maxRateDenom();
+    //         let chargeCycle = await soteriaCoverageProduct.chargeCycle();
+    //         let accountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)
+    //         let maxPermissibleNewCoverLimit = accountBalance.mul(maxRateDenom).div(maxRateNum).div(chargeCycle)
+    //         await expect(soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, maxPermissibleNewCoverLimit.add(ONE_ETH))).to.revertedWith("insufficient deposit for minimum required account balance");
+    //     })
 
-        it("policy owner can update policy", async () => {
-            let activeCoverLimit = initialSoteriaActiveCoverLimit.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
+    //     it("policy owner can update policy", async () => {
+    //         let activeCoverLimit = initialSoteriaActiveCoverLimit.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
             
-            let tx = await soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, NEW_COVER_LIMIT);
+    //         let tx = await soteriaCoverageProduct.connect(policyholder1).updateCoverLimit(POLICY_ID_1, NEW_COVER_LIMIT);
 
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyUpdated").withArgs(POLICY_ID_1);
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(activeCoverLimit);
-            expect(await soteriaCoverageProduct.connect(policyholder1).activeCoverLimit()).to.equal(activeCoverLimit);
-            expect(await soteriaCoverageProduct.connect(policyholder1).coverLimitOf(POLICY_ID_1)).to.equal(NEW_COVER_LIMIT);
-        });
+    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyUpdated").withArgs(POLICY_ID_1);
+    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(activeCoverLimit);
+    //         expect(await soteriaCoverageProduct.connect(policyholder1).activeCoverLimit()).to.equal(activeCoverLimit);
+    //         expect(await soteriaCoverageProduct.connect(policyholder1).coverLimitOf(POLICY_ID_1)).to.equal(NEW_COVER_LIMIT);
+    //     });
 
-        it("governor can update policy", async () => {
-            let TEST_COVER_LIMIT = NEW_COVER_LIMIT.add(ONE_ETH)
-            let activeCoverLimit = initialSoteriaActiveCoverLimit.add(TEST_COVER_LIMIT).sub(initialPolicyCoverLimit);
+    //     it("governor can update policy", async () => {
+    //         let TEST_COVER_LIMIT = NEW_COVER_LIMIT.add(ONE_ETH)
+    //         let activeCoverLimit = initialSoteriaActiveCoverLimit.add(TEST_COVER_LIMIT).sub(initialPolicyCoverLimit);
 
-            let tx = await soteriaCoverageProduct.connect(governor).updateCoverLimit(POLICY_ID_1, TEST_COVER_LIMIT);
+    //         let tx = await soteriaCoverageProduct.connect(governor).updateCoverLimit(POLICY_ID_1, TEST_COVER_LIMIT);
 
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyUpdated").withArgs(POLICY_ID_1);
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(activeCoverLimit);
-            expect(await soteriaCoverageProduct.connect(policyholder1).activeCoverLimit()).to.equal(activeCoverLimit);
-            expect(await soteriaCoverageProduct.connect(policyholder1).coverLimitOf(POLICY_ID_1)).to.equal(TEST_COVER_LIMIT);
+    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyUpdated").withArgs(POLICY_ID_1);
+    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(activeCoverLimit);
+    //         expect(await soteriaCoverageProduct.connect(policyholder1).activeCoverLimit()).to.equal(activeCoverLimit);
+    //         expect(await soteriaCoverageProduct.connect(policyholder1).coverLimitOf(POLICY_ID_1)).to.equal(TEST_COVER_LIMIT);
 
-            // Revert changes
-            await soteriaCoverageProduct.connect(governor).updateCoverLimit(POLICY_ID_1, NEW_COVER_LIMIT);
-        });
+    //         // Revert changes
+    //         await soteriaCoverageProduct.connect(governor).updateCoverLimit(POLICY_ID_1, NEW_COVER_LIMIT);
+    //     });
 
-        it("should update policy manager active cover limit", async () => {
-            let amount1 = initialPMActiveCoverLimit.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
-            let amount2 = initialPMActiveCoverLimitForSoteria.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
+    //     it("should update policy manager active cover limit", async () => {
+    //         let amount1 = initialPMActiveCoverLimit.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
+    //         let amount2 = initialPMActiveCoverLimitForSoteria.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
 
-            expect(await policyManager.connect(governor).activeCoverAmount()).to.equal(amount1);
-            expect(await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(amount2);
-        });
+    //         expect(await policyManager.connect(governor).activeCoverAmount()).to.equal(amount1);
+    //         expect(await policyManager.connect(governor).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(amount2);
+    //     });
 
-        it("should update risk manager mcr", async () => {         
-            let amount1 = initialMCR.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
-            let amount2 = initialMCRForSoteria.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
-            expect(await riskManager.connect(governor).minCapitalRequirement()).to.equal(amount1);
-            expect(await riskManager.connect(governor).minCapitalRequirementPerStrategy(soteriaCoverageProduct.address)).to.equal(amount2);
-        });
-    });
+    //     it("should update risk manager mcr", async () => {         
+    //         let amount1 = initialMCR.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
+    //         let amount2 = initialMCRForSoteria.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
+    //         expect(await riskManager.connect(governor).minCapitalRequirement()).to.equal(amount1);
+    //         expect(await riskManager.connect(governor).minCapitalRequirementPerStrategy(soteriaCoverageProduct.address)).to.equal(amount2);
+    //     });
+    // });
 
-    describe("deactivatePolicy", () => {
-        before(async () => {
-            let tx = await soteriaCoverageProduct.connect(policyholder3).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, {value: ONE_ETH});
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyCreated").withArgs(POLICY_ID_3);
-        });
+    // describe("deactivatePolicy", () => {
+    //     before(async () => {
+    //         let tx = await soteriaCoverageProduct.connect(policyholder3).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, {value: ONE_ETH});
+    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyCreated").withArgs(POLICY_ID_3);
+    //     });
 
-        it("cannot deactivate an invalid policy", async () => {
-            await expect(soteriaCoverageProduct.connect(policyholder3).deactivatePolicy(INVALID_POLICY_ID)).to.revertedWith("invalid policy");
-        });
+    //     it("cannot deactivate an invalid policy", async () => {
+    //         await expect(soteriaCoverageProduct.connect(policyholder3).deactivatePolicy(INVALID_POLICY_ID)).to.revertedWith("invalid policy");
+    //     });
 
-        it("cannot deactivate someone else's policy", async () => {
-            await expect(soteriaCoverageProduct.connect(policyholder3).deactivatePolicy(POLICY_ID_1)).to.revertedWith("not owner or governance");
-        });
+    //     it("cannot deactivate someone else's policy", async () => {
+    //         await expect(soteriaCoverageProduct.connect(policyholder3).deactivatePolicy(POLICY_ID_1)).to.revertedWith("not owner or governance");
+    //     });
 
-        it("policy owner can deactivate policy", async () => {
-            let initialPolicyholderETHBalance = await policyholder3.getBalance();
-            let initialPolicyholderAccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)
-            let initialPolicyCoverLimit = await soteriaCoverageProduct.connect(policyholder3).coverLimitOf(POLICY_ID_3);
-            let initialActiveCoverLimit = await soteriaCoverageProduct.connect(policyholder3).activeCoverLimit();
-            let initialAvailableCoverCapacity = await soteriaCoverageProduct.availableCoverCapacity();
-            let initialPMActiveCoverAmount = await policyManager.connect(policyholder3).activeCoverAmount();
-            let initialPMActiveCoverAmountForSoteria = await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
+    //     it("policy owner can deactivate policy", async () => {
+    //         let initialPolicyholderETHBalance = await policyholder3.getBalance();
+    //         let initialPolicyholderAccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)
+    //         let initialPolicyCoverLimit = await soteriaCoverageProduct.connect(policyholder3).coverLimitOf(POLICY_ID_3);
+    //         let initialActiveCoverLimit = await soteriaCoverageProduct.connect(policyholder3).activeCoverLimit();
+    //         let initialAvailableCoverCapacity = await soteriaCoverageProduct.availableCoverCapacity();
+    //         let initialPMActiveCoverAmount = await policyManager.connect(policyholder3).activeCoverAmount();
+    //         let initialPMActiveCoverAmountForSoteria = await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
 
-            // deactivate policy
-            let tx = await soteriaCoverageProduct.connect(policyholder3).deactivatePolicy(POLICY_ID_3);
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyDeactivated").withArgs(POLICY_ID_3);
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
+    //         // deactivate policy
+    //         let tx = await soteriaCoverageProduct.connect(policyholder3).deactivatePolicy(POLICY_ID_3);
+    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyDeactivated").withArgs(POLICY_ID_3);
+    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
 
-            // user should get refunds
-            let receipt = await tx.wait();
-            let gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice);
-            expect(await policyholder3.getBalance()).eq(initialPolicyholderETHBalance.add(initialPolicyholderAccountBalance).sub(gasCost))
-            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).to.equal(ZERO_AMOUNT);
+    //         // user should get refunds
+    //         let receipt = await tx.wait();
+    //         let gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice);
+    //         expect(await policyholder3.getBalance()).eq(initialPolicyholderETHBalance.add(initialPolicyholderAccountBalance).sub(gasCost))
+    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).to.equal(ZERO_AMOUNT);
 
-            // soteria active cover amount should be decreased
-            expect(await soteriaCoverageProduct.activeCoverLimit()).to.equal(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
+    //         // soteria active cover amount should be decreased
+    //         expect(await soteriaCoverageProduct.activeCoverLimit()).to.equal(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
 
-            // cover limit should be zero
-            expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_3)).to.equal(ZERO_AMOUNT);
-            expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity.add(initialPolicyCoverLimit))
+    //         // cover limit should be zero
+    //         expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_3)).to.equal(ZERO_AMOUNT);
+    //         expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity.add(initialPolicyCoverLimit))
 
-            // policy status should be inactive
-            expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_3)).to.be.false;
-            expect(await soteriaCoverageProduct.policyCount()).eq(3)
+    //         // policy status should be inactive
+    //         expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_3)).to.be.false;
+    //         expect(await soteriaCoverageProduct.policyCount()).eq(3)
 
-            // policy manager active cover amount and active cover amount for soteria should be decreased
-            expect(await policyManager.connect(policyholder3).activeCoverAmount()).to.equal(initialPMActiveCoverAmount.sub(initialPolicyCoverLimit));
-            expect(await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(initialPMActiveCoverAmountForSoteria.sub(initialPolicyCoverLimit));
+    //         // policy manager active cover amount and active cover amount for soteria should be decreased
+    //         expect(await policyManager.connect(policyholder3).activeCoverAmount()).to.equal(initialPMActiveCoverAmount.sub(initialPolicyCoverLimit));
+    //         expect(await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(initialPMActiveCoverAmountForSoteria.sub(initialPolicyCoverLimit));
 
-            // revert for next unit test - governor can deactivate policy
-            await policyholder3.sendTransaction({ to: soteriaCoverageProduct.address, value: initialPolicyholderAccountBalance });
-            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).eq(initialPolicyholderAccountBalance)
-            await soteriaCoverageProduct.connect(policyholder3).activatePolicy(policyholder3.address, initialPolicyCoverLimit)
-            expect(await soteriaCoverageProduct.connect(policyholder3).coverLimitOf(POLICY_ID_3)).eq(initialPolicyCoverLimit)
-            expect(await soteriaCoverageProduct.connect(policyholder3).activeCoverLimit()).eq(initialActiveCoverLimit)
-            expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity)
-            expect(await policyManager.connect(policyholder3).activeCoverAmount()).eq(initialPMActiveCoverAmount)
-            expect(await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).eq(initialPMActiveCoverAmountForSoteria)
-        });
+    //         // revert for next unit test - governor can deactivate policy
+    //         await policyholder3.sendTransaction({ to: soteriaCoverageProduct.address, value: initialPolicyholderAccountBalance });
+    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).eq(initialPolicyholderAccountBalance)
+    //         await soteriaCoverageProduct.connect(policyholder3).activatePolicy(policyholder3.address, initialPolicyCoverLimit)
+    //         expect(await soteriaCoverageProduct.connect(policyholder3).coverLimitOf(POLICY_ID_3)).eq(initialPolicyCoverLimit)
+    //         expect(await soteriaCoverageProduct.connect(policyholder3).activeCoverLimit()).eq(initialActiveCoverLimit)
+    //         expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity)
+    //         expect(await policyManager.connect(policyholder3).activeCoverAmount()).eq(initialPMActiveCoverAmount)
+    //         expect(await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).eq(initialPMActiveCoverAmountForSoteria)
+    //     });
 
-        it("governor can deactivate policy", async () => {
-            let initialPolicyholderETHBalance = await policyholder3.getBalance();
-            let initialPolicyholderAccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)
-            let initialPolicyCoverLimit = await soteriaCoverageProduct.connect(policyholder3).coverLimitOf(POLICY_ID_3);
-            let initialActiveCoverLimit = await soteriaCoverageProduct.connect(policyholder3).activeCoverLimit();
-            let initialAvailableCoverCapacity = await soteriaCoverageProduct.availableCoverCapacity();
-            let initialPMActiveCoverAmount = await policyManager.connect(policyholder3).activeCoverAmount();
-            let initialPMActiveCoverAmountForSoteria = await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
+    //     it("governor can deactivate policy", async () => {
+    //         let initialPolicyholderETHBalance = await policyholder3.getBalance();
+    //         let initialPolicyholderAccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)
+    //         let initialPolicyCoverLimit = await soteriaCoverageProduct.connect(policyholder3).coverLimitOf(POLICY_ID_3);
+    //         let initialActiveCoverLimit = await soteriaCoverageProduct.connect(policyholder3).activeCoverLimit();
+    //         let initialAvailableCoverCapacity = await soteriaCoverageProduct.availableCoverCapacity();
+    //         let initialPMActiveCoverAmount = await policyManager.connect(policyholder3).activeCoverAmount();
+    //         let initialPMActiveCoverAmountForSoteria = await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
 
-            // deactivate policy
-            let tx = await soteriaCoverageProduct.connect(governor).deactivatePolicy(POLICY_ID_3);
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyDeactivated").withArgs(POLICY_ID_3);
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
+    //         // deactivate policy
+    //         let tx = await soteriaCoverageProduct.connect(governor).deactivatePolicy(POLICY_ID_3);
+    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyDeactivated").withArgs(POLICY_ID_3);
+    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyManagerUpdated").withArgs(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
 
-            // user should get refunds
-            let receipt = await tx.wait();
-            let gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice);
-            expect(await policyholder3.getBalance()).eq(initialPolicyholderETHBalance.add(initialPolicyholderAccountBalance))
-            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).to.equal(ZERO_AMOUNT);
+    //         // user should get refunds
+    //         let receipt = await tx.wait();
+    //         let gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice);
+    //         expect(await policyholder3.getBalance()).eq(initialPolicyholderETHBalance.add(initialPolicyholderAccountBalance))
+    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).to.equal(ZERO_AMOUNT);
 
-            // soteria active cover amount should be decreased
-            expect(await soteriaCoverageProduct.activeCoverLimit()).to.equal(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
+    //         // soteria active cover amount should be decreased
+    //         expect(await soteriaCoverageProduct.activeCoverLimit()).to.equal(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
 
-            // cover limit should be zero
-            expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_3)).to.equal(ZERO_AMOUNT);
-            expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity.add(initialPolicyCoverLimit))
+    //         // cover limit should be zero
+    //         expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_3)).to.equal(ZERO_AMOUNT);
+    //         expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity.add(initialPolicyCoverLimit))
 
-            // policy status should be inactive
-            expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_3)).to.be.false;
-            expect(await soteriaCoverageProduct.policyCount()).eq(3)
+    //         // policy status should be inactive
+    //         expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_3)).to.be.false;
+    //         expect(await soteriaCoverageProduct.policyCount()).eq(3)
 
-            // policy manager active cover amount and active cover amount for soteria should be decreased
-            expect(await policyManager.connect(policyholder3).activeCoverAmount()).to.equal(initialPMActiveCoverAmount.sub(initialPolicyCoverLimit));
-            expect(await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(initialPMActiveCoverAmountForSoteria.sub(initialPolicyCoverLimit));
+    //         // policy manager active cover amount and active cover amount for soteria should be decreased
+    //         expect(await policyManager.connect(policyholder3).activeCoverAmount()).to.equal(initialPMActiveCoverAmount.sub(initialPolicyCoverLimit));
+    //         expect(await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(initialPMActiveCoverAmountForSoteria.sub(initialPolicyCoverLimit));
 
-            // revert for next unit test - governor can deactivate policy
-            await soteriaCoverageProduct.connect(governor).deposit(policyholder3.address, {value: initialPolicyholderAccountBalance})
-            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).eq(initialPolicyholderAccountBalance)
-            await soteriaCoverageProduct.connect(governor).activatePolicy(policyholder3.address, initialPolicyCoverLimit)
-            expect(await soteriaCoverageProduct.connect(policyholder3).coverLimitOf(POLICY_ID_3)).eq(initialPolicyCoverLimit)
-            expect(await soteriaCoverageProduct.connect(policyholder3).activeCoverLimit()).eq(initialActiveCoverLimit)
-            expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity)
-            expect(await policyManager.connect(policyholder3).activeCoverAmount()).eq(initialPMActiveCoverAmount)
-            expect(await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).eq(initialPMActiveCoverAmountForSoteria)
-        });
-    });
+    //         // revert for next unit test - governor can deactivate policy
+    //         await soteriaCoverageProduct.connect(governor).deposit(policyholder3.address, {value: initialPolicyholderAccountBalance})
+    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).eq(initialPolicyholderAccountBalance)
+    //         await soteriaCoverageProduct.connect(governor).activatePolicy(policyholder3.address, initialPolicyCoverLimit)
+    //         expect(await soteriaCoverageProduct.connect(policyholder3).coverLimitOf(POLICY_ID_3)).eq(initialPolicyCoverLimit)
+    //         expect(await soteriaCoverageProduct.connect(policyholder3).activeCoverLimit()).eq(initialActiveCoverLimit)
+    //         expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity)
+    //         expect(await policyManager.connect(policyholder3).activeCoverAmount()).eq(initialPMActiveCoverAmount)
+    //         expect(await policyManager.connect(policyholder3).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).eq(initialPMActiveCoverAmountForSoteria)
+    //     });
+    // });
 
-    describe("chargePremiums", () => {
-        it("cannot charge premiums by non-governance", async () => {
-            await expect(soteriaCoverageProduct.connect(policyholder1).chargePremiums([policyholder1.address, policyholder2.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM])).to.revertedWith("!governance");
-        });
+    // describe("chargePremiums", () => {
+    //     it("cannot charge premiums by non-governance", async () => {
+    //         await expect(soteriaCoverageProduct.connect(policyholder1).chargePremiums([policyholder1.address, policyholder2.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM])).to.revertedWith("!governance");
+    //     });
 
-        it("cannot charge premiums if argument lenghts are mismatched", async () => {
-            await expect(soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address, policyholder3.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM])).to.revertedWith("length mismatch");
-        });
+    //     it("cannot charge premiums if argument lenghts are mismatched", async () => {
+    //         await expect(soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address, policyholder3.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM])).to.revertedWith("length mismatch");
+    //     });
 
-        it("cannot charge premiums if policy count is exceeded", async () => {
-            await expect(soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address, policyholder3.address, policyholder4.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM])).to.revertedWith("policy count exceeded");
-        });
+    //     it("cannot charge premiums if policy count is exceeded", async () => {
+    //         await expect(soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address, policyholder3.address, policyholder4.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM])).to.revertedWith("policy count exceeded");
+    //     });
 
-        it("cannot charge more than max rate", async () => {
-            await expect(soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address], [WEEKLY_MAX_PREMIUM.mul(11).div(10), WEEKLY_MAX_PREMIUM.mul(11).div(10)])).to.revertedWith("charging more than promised maximum rate");
-        })
+    //     it("cannot charge more than max rate", async () => {
+    //         await expect(soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address], [WEEKLY_MAX_PREMIUM.mul(11).div(10), WEEKLY_MAX_PREMIUM.mul(11).div(10)])).to.revertedWith("charging more than promised maximum rate");
+    //     })
 
-        it("can charge premiums", async () => {
-            // CASE 1 - Charge weekly premium for two policyholders, no reward points involved
+    //     it("can charge premiums", async () => {
+    //         // CASE 1 - Charge weekly premium for two policyholders, no reward points involved
             
-            // premiums are routed to the vault in treasury!
-            let soteriaBalance = await provider.getBalance(soteriaCoverageProduct.address);
-            let vaultBalance = await provider.getBalance(vault.address);
-            let policyholder1AccountBalance = await soteriaCoverageProduct.connect(policyholder1).accountBalanceOf(policyholder1.address);
-            let policyholder2AccountBalance = await soteriaCoverageProduct.connect(policyholder1).accountBalanceOf(policyholder2.address);
-            let initialCoverLimit1 = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1);
-            let initialCoverLimit2 = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2);
-            let initialActiveCoverLimit = await soteriaCoverageProduct.activeCoverLimit();
-            let initialActiveCoverCapacity = await soteriaCoverageProduct.availableCoverCapacity();
+    //         // premiums are routed to the vault in treasury!
+    //         let soteriaBalance = await provider.getBalance(soteriaCoverageProduct.address);
+    //         let vaultBalance = await provider.getBalance(vault.address);
+    //         let policyholder1AccountBalance = await soteriaCoverageProduct.connect(policyholder1).accountBalanceOf(policyholder1.address);
+    //         let policyholder2AccountBalance = await soteriaCoverageProduct.connect(policyholder1).accountBalanceOf(policyholder2.address);
+    //         let initialCoverLimit1 = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1);
+    //         let initialCoverLimit2 = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2);
+    //         let initialActiveCoverLimit = await soteriaCoverageProduct.activeCoverLimit();
+    //         let initialActiveCoverCapacity = await soteriaCoverageProduct.availableCoverCapacity();
 
-            // charge premiums
-            let tx = soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM]);
-            await expect(tx).emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder1.address, WEEKLY_MAX_PREMIUM);
-            await expect(tx).emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder2.address, WEEKLY_MAX_PREMIUM);
+    //         // charge premiums
+    //         let tx = soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM]);
+    //         await expect(tx).emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder1.address, WEEKLY_MAX_PREMIUM);
+    //         await expect(tx).emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder2.address, WEEKLY_MAX_PREMIUM);
          
-            // Soteria account balance should be decreased
-            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(policyholder1AccountBalance.sub(WEEKLY_MAX_PREMIUM));
-            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder2.address)).to.equal(policyholder2AccountBalance.sub(WEEKLY_MAX_PREMIUM));
+    //         // Soteria account balance should be decreased
+    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).to.equal(policyholder1AccountBalance.sub(WEEKLY_MAX_PREMIUM));
+    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder2.address)).to.equal(policyholder2AccountBalance.sub(WEEKLY_MAX_PREMIUM));
 
-            // soteria balance should be decreased
-            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaBalance.sub(WEEKLY_MAX_PREMIUM.mul(2)));
+    //         // soteria balance should be decreased
+    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(soteriaBalance.sub(WEEKLY_MAX_PREMIUM.mul(2)));
 
-            // premium should be sent to treasury
-            expect(await provider.getBalance(vault.address)).to.equal(vaultBalance.add(WEEKLY_MAX_PREMIUM.mul(2)));
-            expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialActiveCoverCapacity.add(WEEKLY_MAX_PREMIUM.mul(2)))
+    //         // premium should be sent to treasury
+    //         expect(await provider.getBalance(vault.address)).to.equal(vaultBalance.add(WEEKLY_MAX_PREMIUM.mul(2)));
+    //         expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialActiveCoverCapacity.add(WEEKLY_MAX_PREMIUM.mul(2)))
 
-            // following mappings should be unchanged
-            expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1)).eq(initialCoverLimit1)
-            expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2)).eq(initialCoverLimit2)
-            expect(await soteriaCoverageProduct.activeCoverLimit()).eq(initialActiveCoverLimit)
-        });
+    //         // following mappings should be unchanged
+    //         expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1)).eq(initialCoverLimit1)
+    //         expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2)).eq(initialCoverLimit2)
+    //         expect(await soteriaCoverageProduct.activeCoverLimit()).eq(initialActiveCoverLimit)
+    //     });
 
-        it("can partially charge premiums if the fund is insufficient", async () => {
-            // CASE 2 - Activate new policy for new policyholder. Deposit 1.1x WEEKLY_MAX_PREMIUM.
-            // We cannot reach PremiumPartiallyCharged branch within a single chargePremium() call, due to require(minAccountBalance) checks in activatePolicy, updateCoverLimit and chargePremium
-            // So aim to activate it on second chargePremium() call
+    //     it("can partially charge premiums if the fund is insufficient", async () => {
+    //         // CASE 2 - Activate new policy for new policyholder. Deposit 1.1x WEEKLY_MAX_PREMIUM.
+    //         // We cannot reach PremiumPartiallyCharged branch within a single chargePremium() call, due to require(minAccountBalance) checks in activatePolicy, updateCoverLimit and chargePremium
+    //         // So aim to activate it on second chargePremium() call
 
-            let depositAmount = WEEKLY_MAX_PREMIUM.mul(11).div(10)
+    //         let depositAmount = WEEKLY_MAX_PREMIUM.mul(11).div(10)
 
-            let tx = await soteriaCoverageProduct.connect(policyholder4).activatePolicy(policyholder4.address, INITIAL_COVER_LIMIT, {value: depositAmount});
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyCreated").withArgs(POLICY_ID_4);
+    //         let tx = await soteriaCoverageProduct.connect(policyholder4).activatePolicy(policyholder4.address, INITIAL_COVER_LIMIT, {value: depositAmount});
+    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyCreated").withArgs(POLICY_ID_4);
 
-            let initialSoteriaBalance = await provider.getBalance(soteriaCoverageProduct.address);
-            let initialVaultBalance = await provider.getBalance(vault.address);
-            let initialHolderAccountBalance = await soteriaCoverageProduct.connect(policyholder4).accountBalanceOf(policyholder4.address);
-            let initialActiveCoverLimit = await soteriaCoverageProduct.connect(policyholder4).activeCoverLimit();
-            let initialPolicyCoverLimit = await soteriaCoverageProduct.connect(policyholder4).coverLimitOf(POLICY_ID_4);
-            let initialAvailableCoverCapacity = await soteriaCoverageProduct.connect(policyholder4).availableCoverCapacity();
-            let initialPMCoverAmount = await policyManager.connect(policyholder4).activeCoverAmount();
-            let initialPMSoteriaCoverAmount = await policyManager.connect(policyholder4).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
+    //         let initialSoteriaBalance = await provider.getBalance(soteriaCoverageProduct.address);
+    //         let initialVaultBalance = await provider.getBalance(vault.address);
+    //         let initialHolderAccountBalance = await soteriaCoverageProduct.connect(policyholder4).accountBalanceOf(policyholder4.address);
+    //         let initialActiveCoverLimit = await soteriaCoverageProduct.connect(policyholder4).activeCoverLimit();
+    //         let initialPolicyCoverLimit = await soteriaCoverageProduct.connect(policyholder4).coverLimitOf(POLICY_ID_4);
+    //         let initialAvailableCoverCapacity = await soteriaCoverageProduct.connect(policyholder4).availableCoverCapacity();
+    //         let initialPMCoverAmount = await policyManager.connect(policyholder4).activeCoverAmount();
+    //         let initialPMSoteriaCoverAmount = await policyManager.connect(policyholder4).activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
 
-            // we cannot reach the PremiumPartiallyCharged branch within a single chargePremiums() call
-            await soteriaCoverageProduct.connect(governor).chargePremiums([policyholder4.address], [WEEKLY_MAX_PREMIUM]);
-            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder4.address)).eq(WEEKLY_MAX_PREMIUM.div(10))
-            tx = await soteriaCoverageProduct.connect(governor).chargePremiums([policyholder4.address], [WEEKLY_MAX_PREMIUM]);
-            await expect(tx).emit(soteriaCoverageProduct, "PremiumPartiallyCharged").withArgs(policyholder4.address, WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM.div(10));
+    //         // we cannot reach the PremiumPartiallyCharged branch within a single chargePremiums() call
+    //         await soteriaCoverageProduct.connect(governor).chargePremiums([policyholder4.address], [WEEKLY_MAX_PREMIUM]);
+    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder4.address)).eq(WEEKLY_MAX_PREMIUM.div(10))
+    //         tx = await soteriaCoverageProduct.connect(governor).chargePremiums([policyholder4.address], [WEEKLY_MAX_PREMIUM]);
+    //         await expect(tx).emit(soteriaCoverageProduct, "PremiumPartiallyCharged").withArgs(policyholder4.address, WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM.div(10));
            
-            // policy should be deactivated
-            await expect(tx).emit(soteriaCoverageProduct, "PolicyDeactivated").withArgs(POLICY_ID_4);
-            expect(await soteriaCoverageProduct.connect(user).policyStatus(POLICY_ID_4)).to.equal(false);
+    //         // policy should be deactivated
+    //         await expect(tx).emit(soteriaCoverageProduct, "PolicyDeactivated").withArgs(POLICY_ID_4);
+    //         expect(await soteriaCoverageProduct.connect(user).policyStatus(POLICY_ID_4)).to.equal(false);
 
-            // active cover amount should be updated
-            expect(await soteriaCoverageProduct.connect(user).activeCoverLimit()).to.equal(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
-            expect(await soteriaCoverageProduct.connect(policyholder4).availableCoverCapacity()).eq(initialAvailableCoverCapacity.add(depositAmount).add(initialPolicyCoverLimit))
+    //         // active cover amount should be updated
+    //         expect(await soteriaCoverageProduct.connect(user).activeCoverLimit()).to.equal(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
+    //         expect(await soteriaCoverageProduct.connect(policyholder4).availableCoverCapacity()).eq(initialAvailableCoverCapacity.add(depositAmount).add(initialPolicyCoverLimit))
 
-            // policy's cover amount should be zero
-            expect(await soteriaCoverageProduct.connect(user).coverLimitOf(POLICY_ID_4)).to.equal(ZERO_AMOUNT);
+    //         // policy's cover amount should be zero
+    //         expect(await soteriaCoverageProduct.connect(user).coverLimitOf(POLICY_ID_4)).to.equal(ZERO_AMOUNT);
 
-            // policy manager should be updated
-            expect(await policyManager.connect(user).activeCoverAmount()).to.equal(initialPMCoverAmount.sub(initialPolicyCoverLimit));
-            expect(await policyManager.connect(user).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(initialPMSoteriaCoverAmount.sub(initialPolicyCoverLimit));
-            expect(await policyManager.connect(user).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
+    //         // policy manager should be updated
+    //         expect(await policyManager.connect(user).activeCoverAmount()).to.equal(initialPMCoverAmount.sub(initialPolicyCoverLimit));
+    //         expect(await policyManager.connect(user).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(initialPMSoteriaCoverAmount.sub(initialPolicyCoverLimit));
+    //         expect(await policyManager.connect(user).activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).to.equal(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
 
-            // policyholder funds should be zero
-            expect(await soteriaCoverageProduct.connect(user).accountBalanceOf(policyholder4.address)).to.equal(ZERO_AMOUNT);
+    //         // policyholder funds should be zero
+    //         expect(await soteriaCoverageProduct.connect(user).accountBalanceOf(policyholder4.address)).to.equal(ZERO_AMOUNT);
 
-            // soteria balance should be decreased
-            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(initialSoteriaBalance.sub(depositAmount));
+    //         // soteria balance should be decreased
+    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(initialSoteriaBalance.sub(depositAmount));
             
-            // premium should be sent to treasury
-            expect(await provider.getBalance(vault.address)).to.equal(initialVaultBalance.add(depositAmount));
-        });
+    //         // premium should be sent to treasury
+    //         expect(await provider.getBalance(vault.address)).to.equal(initialVaultBalance.add(depositAmount));
+    //     });
 
-        it("will skip charging premium for inactive accounts", async () => {
-            // CASE 3 - Charge weekly premium for one active, and one inactive account (made inactive in CASE 2)
+    //     it("will skip charging premium for inactive accounts", async () => {
+    //         // CASE 3 - Charge weekly premium for one active, and one inactive account (made inactive in CASE 2)
 
-            let initialSoteriaBalance = await provider.getBalance(soteriaCoverageProduct.address);
-            let initialVaultBalance = await provider.getBalance(vault.address);
-            let initialHolderFunds = await soteriaCoverageProduct.connect(policyholder2).accountBalanceOf(policyholder2.address);
+    //         let initialSoteriaBalance = await provider.getBalance(soteriaCoverageProduct.address);
+    //         let initialVaultBalance = await provider.getBalance(vault.address);
+    //         let initialHolderFunds = await soteriaCoverageProduct.connect(policyholder2).accountBalanceOf(policyholder2.address);
 
-            expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_4)).to.equal(false);
-            expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_2)).to.equal(true);
+    //         expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_4)).to.equal(false);
+    //         expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_2)).to.equal(true);
 
-            // charge premiums
-            let tx = soteriaCoverageProduct.connect(governor).chargePremiums([policyholder2.address, policyholder4.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM]);
-            await expect(tx).emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder2.address, WEEKLY_MAX_PREMIUM);
+    //         // charge premiums
+    //         let tx = soteriaCoverageProduct.connect(governor).chargePremiums([policyholder2.address, policyholder4.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM]);
+    //         await expect(tx).emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder2.address, WEEKLY_MAX_PREMIUM);
          
-            expect(await soteriaCoverageProduct.connect(policyholder2).accountBalanceOf(policyholder2.address)).to.equal(initialHolderFunds.sub(WEEKLY_MAX_PREMIUM));
+    //         expect(await soteriaCoverageProduct.connect(policyholder2).accountBalanceOf(policyholder2.address)).to.equal(initialHolderFunds.sub(WEEKLY_MAX_PREMIUM));
          
-            // soteria balance should be decreased by single weekly premium
-            expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(initialSoteriaBalance.sub(WEEKLY_MAX_PREMIUM));
+    //         // soteria balance should be decreased by single weekly premium
+    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).to.equal(initialSoteriaBalance.sub(WEEKLY_MAX_PREMIUM));
           
-            // single weekly premium should be sent to treasury
-            expect(await provider.getBalance(vault.address)).to.equal(initialVaultBalance.add(WEEKLY_MAX_PREMIUM));
-        });
+    //         // single weekly premium should be sent to treasury
+    //         expect(await provider.getBalance(vault.address)).to.equal(initialVaultBalance.add(WEEKLY_MAX_PREMIUM));
+    //     });
 
-        it("will correctly charge premiums with reward points", async () => {
-            // CASE 4 - Charge weekly premium for three active policies
-            // Policy 1: reward points can pay for premium in full
-            // Policy 2: reward points can partially pay for premium, rest will come from account balance
-            // Policy 3: reward points + account balance unable to fully pay for premium
+    //     it("will correctly charge premiums with reward points", async () => {
+    //         // CASE 4 - Charge weekly premium for three active policies
+    //         // Policy 1: reward points can pay for premium in full
+    //         // Policy 2: reward points can partially pay for premium, rest will come from account balance
+    //         // Policy 3: reward points + account balance unable to fully pay for premium
 
-            // Set up reward points for policy 1 and 2
-            let EXCESS_REWARD_POINTS = WEEKLY_MAX_PREMIUM.mul(2)
-            let INSUFFICIENT_REWARD_POINTS = WEEKLY_MAX_PREMIUM.div(10)
+    //         // Set up reward points for policy 1 and 2
+    //         let EXCESS_REWARD_POINTS = WEEKLY_MAX_PREMIUM.mul(2)
+    //         let INSUFFICIENT_REWARD_POINTS = WEEKLY_MAX_PREMIUM.div(10)
 
-            let tx = await soteriaCoverageProduct.connect(governor).setRewardPoints(policyholder1.address, EXCESS_REWARD_POINTS)
-            expect(tx).to.emit(soteriaCoverageProduct, "RewardPointsSet").withArgs(policyholder1.address, EXCESS_REWARD_POINTS);
-            let initialRewardPoints1 = await soteriaCoverageProduct.rewardPointsOf(policyholder1.address)
-            expect(initialRewardPoints1).eq(EXCESS_REWARD_POINTS)
+    //         let tx = await soteriaCoverageProduct.connect(governor).setRewardPoints(policyholder1.address, EXCESS_REWARD_POINTS)
+    //         expect(tx).to.emit(soteriaCoverageProduct, "RewardPointsSet").withArgs(policyholder1.address, EXCESS_REWARD_POINTS);
+    //         let initialRewardPoints1 = await soteriaCoverageProduct.rewardPointsOf(policyholder1.address)
+    //         expect(initialRewardPoints1).eq(EXCESS_REWARD_POINTS)
 
-            tx = await soteriaCoverageProduct.connect(governor).setRewardPoints(policyholder2.address, INSUFFICIENT_REWARD_POINTS)
-            expect(tx).to.emit(soteriaCoverageProduct, "RewardPointsSet").withArgs(policyholder2.address, INSUFFICIENT_REWARD_POINTS);
-            let initialRewardPoints2 = await soteriaCoverageProduct.rewardPointsOf(policyholder2.address)
-            expect(initialRewardPoints2).eq(INSUFFICIENT_REWARD_POINTS)
+    //         tx = await soteriaCoverageProduct.connect(governor).setRewardPoints(policyholder2.address, INSUFFICIENT_REWARD_POINTS)
+    //         expect(tx).to.emit(soteriaCoverageProduct, "RewardPointsSet").withArgs(policyholder2.address, INSUFFICIENT_REWARD_POINTS);
+    //         let initialRewardPoints2 = await soteriaCoverageProduct.rewardPointsOf(policyholder2.address)
+    //         expect(initialRewardPoints2).eq(INSUFFICIENT_REWARD_POINTS)
 
-            // Set up policy 3 (remember we need minimum 2 chargePremium calls to reach PremiumsPartiallySet branch, so we will do the first call to setup)
-            await soteriaCoverageProduct.connect(policyholder3).deactivatePolicy(POLICY_ID_3);
-            let depositAmount = WEEKLY_MAX_PREMIUM.mul(11).div(10)
-            await soteriaCoverageProduct.connect(policyholder3).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, {value: depositAmount});
-            await soteriaCoverageProduct.connect(governor).chargePremiums([policyholder3.address], [WEEKLY_MAX_PREMIUM]);
-            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).eq(WEEKLY_MAX_PREMIUM.div(10))
+    //         // Set up policy 3 (remember we need minimum 2 chargePremium calls to reach PremiumsPartiallySet branch, so we will do the first call to setup)
+    //         await soteriaCoverageProduct.connect(policyholder3).deactivatePolicy(POLICY_ID_3);
+    //         let depositAmount = WEEKLY_MAX_PREMIUM.mul(11).div(10)
+    //         await soteriaCoverageProduct.connect(policyholder3).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, {value: depositAmount});
+    //         await soteriaCoverageProduct.connect(governor).chargePremiums([policyholder3.address], [WEEKLY_MAX_PREMIUM]);
+    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).eq(WEEKLY_MAX_PREMIUM.div(10))
 
-            tx = await soteriaCoverageProduct.connect(governor).setRewardPoints(policyholder3.address, INSUFFICIENT_REWARD_POINTS)
-            expect(tx).to.emit(soteriaCoverageProduct, "RewardPointsSet").withArgs(policyholder3.address, INSUFFICIENT_REWARD_POINTS);
-            let initialRewardPoints3 = await soteriaCoverageProduct.rewardPointsOf(policyholder3.address)
-            expect(initialRewardPoints3).eq(INSUFFICIENT_REWARD_POINTS)
+    //         tx = await soteriaCoverageProduct.connect(governor).setRewardPoints(policyholder3.address, INSUFFICIENT_REWARD_POINTS)
+    //         expect(tx).to.emit(soteriaCoverageProduct, "RewardPointsSet").withArgs(policyholder3.address, INSUFFICIENT_REWARD_POINTS);
+    //         let initialRewardPoints3 = await soteriaCoverageProduct.rewardPointsOf(policyholder3.address)
+    //         expect(initialRewardPoints3).eq(INSUFFICIENT_REWARD_POINTS)
 
-            // Get initial state variable values
-            let initialSoteriaBalance = await provider.getBalance(soteriaCoverageProduct.address);
-            let initialVaultBalance = await provider.getBalance(vault.address);
-            let initialHolder1AccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
-            let initialHolder2AccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder2.address);
-            let initialHolder3AccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder3.address);
-            let initialActiveCoverLimit = await soteriaCoverageProduct.activeCoverLimit();
-            let initialPolicy1CoverLimit = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1);
-            let initialPolicy2CoverLimit = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2);
-            let initialPolicy3CoverLimit = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_3);
-            let initialAvailableCoverCapacity = await soteriaCoverageProduct.availableCoverCapacity();
-            let initialPMCoverAmount = await policyManager.activeCoverAmount();
-            let initialPMSoteriaCoverAmount = await policyManager.activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
+    //         // Get initial state variable values
+    //         let initialSoteriaBalance = await provider.getBalance(soteriaCoverageProduct.address);
+    //         let initialVaultBalance = await provider.getBalance(vault.address);
+    //         let initialHolder1AccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder1.address);
+    //         let initialHolder2AccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder2.address);
+    //         let initialHolder3AccountBalance = await soteriaCoverageProduct.accountBalanceOf(policyholder3.address);
+    //         let initialActiveCoverLimit = await soteriaCoverageProduct.activeCoverLimit();
+    //         let initialPolicy1CoverLimit = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1);
+    //         let initialPolicy2CoverLimit = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2);
+    //         let initialPolicy3CoverLimit = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_3);
+    //         let initialAvailableCoverCapacity = await soteriaCoverageProduct.availableCoverCapacity();
+    //         let initialPMCoverAmount = await policyManager.activeCoverAmount();
+    //         let initialPMSoteriaCoverAmount = await policyManager.activeCoverAmountPerStrategy(soteriaCoverageProduct.address);
 
-            tx = await soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address, policyholder3.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM])
-            expect(tx).to.emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder1.address, WEEKLY_MAX_PREMIUM);
-            expect(tx).to.emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder2.address, WEEKLY_MAX_PREMIUM);
-            expect(tx).to.emit(soteriaCoverageProduct, "PremiumPartiallyCharged").withArgs(policyholder3.address, WEEKLY_MAX_PREMIUM, initialHolder3AccountBalance.add(initialRewardPoints3));
-            expect(tx).to.emit(soteriaCoverageProduct, "PolicyDeactivated").withArgs(POLICY_ID_3);
+    //         tx = await soteriaCoverageProduct.connect(governor).chargePremiums([policyholder1.address, policyholder2.address, policyholder3.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM])
+    //         expect(tx).to.emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder1.address, WEEKLY_MAX_PREMIUM);
+    //         expect(tx).to.emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder2.address, WEEKLY_MAX_PREMIUM);
+    //         expect(tx).to.emit(soteriaCoverageProduct, "PremiumPartiallyCharged").withArgs(policyholder3.address, WEEKLY_MAX_PREMIUM, initialHolder3AccountBalance.add(initialRewardPoints3));
+    //         expect(tx).to.emit(soteriaCoverageProduct, "PolicyDeactivated").withArgs(POLICY_ID_3);
 
-            // Confirm state is what we expect after charging premium
+    //         // Confirm state is what we expect after charging premium
 
-            // Check reward points
-            expect(await soteriaCoverageProduct.rewardPointsOf(policyholder1.address)).eq(initialRewardPoints1.sub(WEEKLY_MAX_PREMIUM))            
-            expect(await soteriaCoverageProduct.rewardPointsOf(policyholder2.address)).eq(0)          
-            expect(await soteriaCoverageProduct.rewardPointsOf(policyholder2.address)).eq(0)          
+    //         // Check reward points
+    //         expect(await soteriaCoverageProduct.rewardPointsOf(policyholder1.address)).eq(initialRewardPoints1.sub(WEEKLY_MAX_PREMIUM))            
+    //         expect(await soteriaCoverageProduct.rewardPointsOf(policyholder2.address)).eq(0)          
+    //         expect(await soteriaCoverageProduct.rewardPointsOf(policyholder2.address)).eq(0)          
 
-            // Check account balances
-            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).eq(initialHolder1AccountBalance)
-            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder2.address)).eq(initialHolder2AccountBalance.sub(WEEKLY_MAX_PREMIUM).add(initialRewardPoints2))
-            expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).eq(0)
+    //         // Check account balances
+    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder1.address)).eq(initialHolder1AccountBalance)
+    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder2.address)).eq(initialHolder2AccountBalance.sub(WEEKLY_MAX_PREMIUM).add(initialRewardPoints2))
+    //         expect(await soteriaCoverageProduct.accountBalanceOf(policyholder3.address)).eq(0)
 
-            // Check cover limits
-            expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1)).eq(initialPolicy1CoverLimit)
-            expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2)).eq(initialPolicy2CoverLimit)
-            expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_3)).eq(0)
+    //         // Check cover limits
+    //         expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_1)).eq(initialPolicy1CoverLimit)
+    //         expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2)).eq(initialPolicy2CoverLimit)
+    //         expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_3)).eq(0)
 
-            // Check policy status
-            expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_1)).eq(true)
-            expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_2)).eq(true)
-            expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_3)).eq(false)
+    //         // Check policy status
+    //         expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_1)).eq(true)
+    //         expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_2)).eq(true)
+    //         expect(await soteriaCoverageProduct.policyStatus(POLICY_ID_3)).eq(false)
 
-            // Soteria balance check
-            let accountBalanceDeductedForHolder1 = BN.from("0");
-            let accountBalanceDeductedForHolder2 = WEEKLY_MAX_PREMIUM.sub(initialRewardPoints2);
-            let accountBalanceDeductedForHolder3 = initialHolder3AccountBalance;
-            let expectedSoteriaBalanceChange = accountBalanceDeductedForHolder1.add(accountBalanceDeductedForHolder2).add(accountBalanceDeductedForHolder3)
-            expect(await provider.getBalance(soteriaCoverageProduct.address)).eq(initialSoteriaBalance.sub(expectedSoteriaBalanceChange))
+    //         // Soteria balance check
+    //         let accountBalanceDeductedForHolder1 = BN.from("0");
+    //         let accountBalanceDeductedForHolder2 = WEEKLY_MAX_PREMIUM.sub(initialRewardPoints2);
+    //         let accountBalanceDeductedForHolder3 = initialHolder3AccountBalance;
+    //         let expectedSoteriaBalanceChange = accountBalanceDeductedForHolder1.add(accountBalanceDeductedForHolder2).add(accountBalanceDeductedForHolder3)
+    //         expect(await provider.getBalance(soteriaCoverageProduct.address)).eq(initialSoteriaBalance.sub(expectedSoteriaBalanceChange))
 
-            // Vault balance check
-            expect(await provider.getBalance(vault.address)).eq(initialVaultBalance.add(expectedSoteriaBalanceChange))
+    //         // Vault balance check
+    //         expect(await provider.getBalance(vault.address)).eq(initialVaultBalance.add(expectedSoteriaBalanceChange))
 
-            // Soteria active cover limit check - policy 3 deactivated
-            expect(await soteriaCoverageProduct.activeCoverLimit()).eq(initialActiveCoverLimit.sub(initialPolicy3CoverLimit))
-            expect(await policyManager.activeCoverAmount()).eq(initialPMCoverAmount.sub(initialPolicy3CoverLimit))
-            expect(await policyManager.activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).eq(initialPMSoteriaCoverAmount.sub(initialPolicy3CoverLimit))
+    //         // Soteria active cover limit check - policy 3 deactivated
+    //         expect(await soteriaCoverageProduct.activeCoverLimit()).eq(initialActiveCoverLimit.sub(initialPolicy3CoverLimit))
+    //         expect(await policyManager.activeCoverAmount()).eq(initialPMCoverAmount.sub(initialPolicy3CoverLimit))
+    //         expect(await policyManager.activeCoverAmountPerStrategy(soteriaCoverageProduct.address)).eq(initialPMSoteriaCoverAmount.sub(initialPolicy3CoverLimit))
             
-            // Cover capacity check - maxCover() increased by vault deposits, active cover limit decreased by policy 3 initial cover limit
-            expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity.add(expectedSoteriaBalanceChange).add(initialPolicy3CoverLimit))
-        })
+    //         // Cover capacity check - maxCover() increased by vault deposits, active cover limit decreased by policy 3 initial cover limit
+    //         expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity.add(expectedSoteriaBalanceChange).add(initialPolicy3CoverLimit))
+    //     })
 
-        it("will charge for 100 users in one call", async() => {
-            // Create 100 test wallets
-            // 100 wallets -> 1.6M gas
-            // 1000 wallets -> 16M gas
-            let numberWallets = 100 // Change this number to whatever number of wallets you want to test for
+    //     it("will charge for 100 users in one call", async() => {
+    //         // Create 100 test wallets
+    //         // 100 wallets -> 1.6M gas
+    //         // 1000 wallets -> 16M gas
+    //         let numberWallets = 100 // Change this number to whatever number of wallets you want to test for
 
-            let users:(Wallet)[] = [];
-            for (let i = 0; i < numberWallets; i++) {
-                users.push(provider.createEmptyWallet())
-            }
-            // Activate policies for each user, 1 ETH cover limit with 0.1 ETH deposit
-            for (let user of users) {
-                await soteriaCoverageProduct.connect(governor).activatePolicy(user.address, ONE_ETH, {value:ONE_ETH.div(10)})
-            }
-            // Gift 0 reward points to one-third of users, half-weekly premium to one-third, and full weekly premium to remaining third
-            for (let user of users) {
-                if ( Math.floor(Math.random() * 3) == 0 ) {
-                    await soteriaCoverageProduct.connect(governor).setRewardPoints(user.address, WEEKLY_MAX_PREMIUM.div(2))
-                } else if ( Math.floor(Math.random() * 3) == 1 ) {
-                    await soteriaCoverageProduct.connect(governor).setRewardPoints(user.address, WEEKLY_MAX_PREMIUM)
-                }
-            }
-            // Create arrays for chargePremium parameter
-            let PREMIUM_ARRAY:BN[] = []
-            let ADDRESS_ARRAY:string[] = []
-            for (let user of users) {
-                ADDRESS_ARRAY.push(user.address)
-                PREMIUM_ARRAY.push(WEEKLY_MAX_PREMIUM)
-            }
+    //         let users:(Wallet)[] = [];
+    //         for (let i = 0; i < numberWallets; i++) {
+    //             users.push(provider.createEmptyWallet())
+    //         }
+    //         // Activate policies for each user, 1 ETH cover limit with 0.1 ETH deposit
+    //         for (let user of users) {
+    //             await soteriaCoverageProduct.connect(governor).activatePolicy(user.address, ONE_ETH, {value:ONE_ETH.div(10)})
+    //         }
+    //         // Gift 0 reward points to one-third of users, half-weekly premium to one-third, and full weekly premium to remaining third
+    //         for (let user of users) {
+    //             if ( Math.floor(Math.random() * 3) == 0 ) {
+    //                 await soteriaCoverageProduct.connect(governor).setRewardPoints(user.address, WEEKLY_MAX_PREMIUM.div(2))
+    //             } else if ( Math.floor(Math.random() * 3) == 1 ) {
+    //                 await soteriaCoverageProduct.connect(governor).setRewardPoints(user.address, WEEKLY_MAX_PREMIUM)
+    //             }
+    //         }
+    //         // Create arrays for chargePremium parameter
+    //         let PREMIUM_ARRAY:BN[] = []
+    //         let ADDRESS_ARRAY:string[] = []
+    //         for (let user of users) {
+    //             ADDRESS_ARRAY.push(user.address)
+    //             PREMIUM_ARRAY.push(WEEKLY_MAX_PREMIUM)
+    //         }
 
-            // Charge premiums
-            await soteriaCoverageProduct.connect(governor).chargePremiums(ADDRESS_ARRAY, PREMIUM_ARRAY);
-        })
-    // Test for maxing out users
+    //         // Charge premiums
+    //         await soteriaCoverageProduct.connect(governor).chargePremiums(ADDRESS_ARRAY, PREMIUM_ARRAY);
+    //     })
+    // // Test for maxing out users
 
-    });
+    // });
 
 });

--- a/test/SoteriaCoverageProduct.test.ts
+++ b/test/SoteriaCoverageProduct.test.ts
@@ -801,8 +801,8 @@ describe("SoteriaCoverageProduct", function() {
             let initialActiveCoverLimit = await soteriaCoverageProduct.connect(policyholder4).activeCoverLimit();
             let initialPolicyCoverLimit = await soteriaCoverageProduct.connect(policyholder4).coverLimitOf(POLICY_ID_4);
             let initialAvailableCoverCapacity = await soteriaCoverageProduct.connect(policyholder4).availableCoverCapacity();
-            let initialPMCoverAmount = await riskManager.connect(policyholder4).activeCoverLimit();
-            let initialPMSoteriaCoverAmount = await riskManager.connect(policyholder4).activeCoverLimitPerStrategy(soteriaCoverageProduct.address);
+            let initialRMCoverAmount = await riskManager.connect(policyholder4).activeCoverLimit();
+            let initialRMSoteriaCoverAmount = await riskManager.connect(policyholder4).activeCoverLimitPerStrategy(soteriaCoverageProduct.address);
 
             // we cannot reach the PremiumPartiallyCharged branch within a single chargePremiums() call
             await soteriaCoverageProduct.connect(premiumCollector).chargePremiums([policyholder4.address], [WEEKLY_MAX_PREMIUM]);
@@ -823,8 +823,8 @@ describe("SoteriaCoverageProduct", function() {
             expect(await soteriaCoverageProduct.coverLimitOf(POLICY_ID_4)).to.equal(ZERO_AMOUNT);
 
             // risk manager should be updated
-            expect(await riskManager.activeCoverLimit()).to.equal(initialPMCoverAmount.sub(initialPolicyCoverLimit));
-            expect(await riskManager.activeCoverLimitPerStrategy(soteriaCoverageProduct.address)).to.equal(initialPMSoteriaCoverAmount.sub(initialPolicyCoverLimit));
+            expect(await riskManager.activeCoverLimit()).to.equal(initialRMCoverAmount.sub(initialPolicyCoverLimit));
+            expect(await riskManager.activeCoverLimitPerStrategy(soteriaCoverageProduct.address)).to.equal(initialRMSoteriaCoverAmount.sub(initialPolicyCoverLimit));
             expect(await riskManager.activeCoverLimitPerStrategy(soteriaCoverageProduct.address)).to.equal(initialActiveCoverLimit.sub(initialPolicyCoverLimit));
 
             // policyholder account balance should be depleted
@@ -903,8 +903,8 @@ describe("SoteriaCoverageProduct", function() {
             let initialPolicy2CoverLimit = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_2);
             let initialPolicy3CoverLimit = await soteriaCoverageProduct.coverLimitOf(POLICY_ID_3);
             let initialAvailableCoverCapacity = await soteriaCoverageProduct.availableCoverCapacity();
-            let initialPMCoverAmount = await riskManager.activeCoverLimit();
-            let initialPMSoteriaCoverAmount = await riskManager.activeCoverLimitPerStrategy(soteriaCoverageProduct.address);
+            let initialRMCoverAmount = await riskManager.activeCoverLimit();
+            let initialRMSoteriaCoverAmount = await riskManager.activeCoverLimitPerStrategy(soteriaCoverageProduct.address);
 
             tx = await soteriaCoverageProduct.connect(premiumCollector).chargePremiums([policyholder1.address, policyholder2.address, policyholder3.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM])
             expect(tx).to.emit(soteriaCoverageProduct, "PremiumCharged").withArgs(policyholder1.address, WEEKLY_MAX_PREMIUM);
@@ -947,8 +947,8 @@ describe("SoteriaCoverageProduct", function() {
 
             // Soteria active cover limit check - policy 3 deactivated
             expect(await soteriaCoverageProduct.activeCoverLimit()).eq(initialActiveCoverLimit.sub(initialPolicy3CoverLimit))
-            expect(await riskManager.activeCoverLimit()).eq(initialPMCoverAmount.sub(initialPolicy3CoverLimit))
-            expect(await riskManager.activeCoverLimitPerStrategy(soteriaCoverageProduct.address)).eq(initialPMSoteriaCoverAmount.sub(initialPolicy3CoverLimit))
+            expect(await riskManager.activeCoverLimit()).eq(initialRMCoverAmount.sub(initialPolicy3CoverLimit))
+            expect(await riskManager.activeCoverLimitPerStrategy(soteriaCoverageProduct.address)).eq(initialRMSoteriaCoverAmount.sub(initialPolicy3CoverLimit))
             
             // Cover capacity check - should be increased by policy 3 initial cover limit
             expect(await soteriaCoverageProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity.add(initialPolicy3CoverLimit))

--- a/test/Treasury.test.ts
+++ b/test/Treasury.test.ts
@@ -97,7 +97,7 @@ describe("Treasury", function() {
     await registry.connect(governor).setTreasury(treasury.address);
 
     // deploy policy manager
-    policyManager = (await deployContract(deployer, artifacts.PolicyManager, [governor.address])) as PolicyManager;
+    policyManager = (await deployContract(deployer, artifacts.PolicyManager, [governor.address, registry.address])) as PolicyManager;
     await registry.connect(governor).setPolicyManager(policyManager.address);
 
     // transfer tokens

--- a/test/Vault.test.ts
+++ b/test/Vault.test.ts
@@ -25,7 +25,7 @@ describe("Vault", function () {
   let mockRiskStrategy: MockRiskStrategy;
   let productFactory: ProductFactory;
 
-  const [owner, newOwner, depositor1, depositor2, mockEscrow, solace, solaceUsdcPool, priceOracle ] = provider.getWallets();
+  const [owner, newOwner, depositor1, depositor2, mockEscrow, solace, solaceUsdcPool, priceOracle, underwritingPool] = provider.getWallets();
   const tokenName = "Solace CP Token";
   const tokenSymbol = "SCP";
   const testDepositAmount1 = BN.from("1000000000000000000"); // one eth
@@ -54,7 +54,7 @@ describe("Vault", function () {
     await registry.setVault(vault.address);
     claimsEscrow = (await deployContract(owner,artifacts.ClaimsEscrow,[owner.address,registry.address])) as ClaimsEscrow;
     await registry.setClaimsEscrow(claimsEscrow.address);
-    policyManager = (await deployContract(owner,artifacts.PolicyManager,[owner.address])) as PolicyManager;
+    policyManager = (await deployContract(owner,artifacts.PolicyManager,[owner.address, registry.address])) as PolicyManager;
     await registry.setPolicyManager(policyManager.address);
     riskManager = (await deployContract(owner, artifacts.RiskManager, [owner.address, registry.address])) as RiskManager;
     await registry.setRiskManager(riskManager.address);


### PR DESCRIPTION
**TODO**
- Within contracts other than SoteriaCoverageProduct.sol, rename “coverAmount” to “coverLimit”. Looking at PolicyManager.sol in particular.
- Work out specifications for referral discount mechanism, and then implement this
- Work out specifications for staking duration discount mechanism, and then implement this
- Work out specifications for withdraw cooldown mechanism
- For discussion - For chargePremium should we keep `require(premiums_[i] <= _minRequiredAccountBalance(coverLimitOf(policyOf(holders_[i]))), "charging more than promised maximum rate");`
- For discussion - For _canPurchaseNewCover() function, should we keep `if (newTotalCover_ < existingTotalCover_) return true;`

-----------------------

**COMMIT LOG**

**Soteria refactor 6**

Realised needed to split _maxRate into _maxRateNum and _maxRateDenom, because 10% annual rate => _maxRate = 1/315360000

**Soteria refactor 5** 

Renamed _closePolicy to _deactivatePolicy, implemented calls to _deactivatePolicy() in both deactivatePolicy() and chargePremiums()

**Soteria refactor 4**

Added sanity check to withdraw() and _canPurchaseNewCover()

Renamed _rewardPoints mapping to _rewardPointsOf

Changed giftRewardPoints() to setRewardPoints()

**Soteria refactor 3**

Added _beforeTokenTransfer(…) hook to ensure
- Soteria policies are non-transferable
- Only one Soteria policy can be minted per user

Renamed totalCoverLimit to activeCoverLimit (as per specs)

Added chargeCycle variable, as well as related public getter and governance-only setter functions.

Changed maxChargeableRate to maxRate. 

require (minAccountBalance = maxRate * chargeCycle * coverLimit) is incorporated into activatePolicy(), updatePolicy(), and withdraw()

Made sure withdraw() function follows these specs:
- Cannot withdraw more 
- Sends funds to the policyholder
- NEED CLARIFICATION HERE - User can only withdraw such that remaining balance >minAccountBalance, else they will withdraw all available balance (which is the same thing as deactivatePolicy?)
- _withdraw(address policyholder_, uint256 amount_) internal {…}
- Transfer funds to policyholder

Renamed _soteriaAccountBalance mapping to _accountBalanceOf

Made sure activatePolicy(…) follows these specs:
- require minAccountBalance = maxRate * coverLimit_ * chargeCycle
- Call _deposit() -> _accountBalanceOf(policyholder) = msg.value
- Call mint()
- require coverLimit <= availableCoverCapacity (this requires a call to maxCover, which requires a call to RiskManager)
- report activeCover to PolicyManager (Need to change to RiskManager)
- Add to mapping: policyOf(policyholder)=policyID
- Add to mapping: coverLimitOf(policyholder)=coverLimit_

**Soteria refactor 2**

- Renamed cancelPolicy() to deactivatePolicy(), and event PolicyCancelled to PolicyDeactivated
- Removed functions, variables and events related to ‘Signers’ mechanism

**Soteria refactor 1**

- Removed submitClaim() function (rationale - for the first product iteration, we will assess claims off-chain and send payouts proactively)
- Renamed references of “coverAmount” to “coverLimit” (rationale - coverAmount is misleading, coverLimit is more accurate description)
- Renamed _funds mapping to _soteriaAccountBalance (rationale - more accurate variable name)
- Renamed funds() view function to soteriaAccountBalance() (rationale - more accurate variable name)
- Removed _policyToOwner() mapping (rationale - ERC721.ownerOf() function does the same thing)
- Removed policyholders() function (rationale - We can return all policy holders by using a combination of policyCount() to get total supply => query ERC721.ownerOf() for each number)
- Removed minFundAmount_ parameter from activatePolicy() (rationale - redundant parameter)
- Renamed policyByOwner() to policyIDOf (rationale - more human readable function)
- Renamed mapping _ownerToPolicy to _policyID (rationale - more human readable function)
- Added newCoverCapacity() view function (rationale - useful to view amount of available capacity for new cover)
- Renamed assessRisk() to _canPurchaseNewCover() and made this an internal function (rationale - assessRisk is misleading, since risk managers do this off-chain, and this function actually checks to see if there is capacity for a new requested coverage limit. Made internal function because this should only be called by activatePolicy() and updateCoverLimit() functions)
- Renamed _activeCoverAmount and activeCoverAmount() to _totalActiveCover and totalActiveCover (rationale - more accurate variable name)
- Created _rewardPoints mapping to enable mechanisms of gifting free cover, and getting referral discounts. Incorporated _rewardPoints mapping into chargePremium() logic. 
- Added giftRewardPoints() function to enable governance to gift free points to selected address
- Added _maxChargeablePremium internal state variable and maxChargeablePremium public getter function. Added setMaxChargeablePremium governance function.
- Modified updateCoverLimit(...) function to be accessed be either policy holder or governance, and thus added one parameter `uint256 policyID_`. Also refactored the function logic.
- Added withdraw() function to enable voluntary withdraws. Enforced condition that user cannot withdraw below a soteriaAccountBalance of “currentCoverLimit * maxChargeablePremium”

DISCUSSED CHANGES THAT I’VE DECIDED TO KEEP IN THIS PR
- Removing _totalPolicyCount in favour of using ERC721.totalSupply(). OpenZeppelin implementation of the ERC721 standard does not have a totalSupply() method - https://docs.openzeppelin.com/contracts/2.x/api/token/erc721. To get a totalSupply() method, we need to inherit ERC721Enumerable.sol, or the method (saves 70% gas on NFT mint compared to inheriting ERC721Enumerable.sol) described here https://shiny.mirror.xyz/OUampBbIz9ebEicfGnQf5At_ReMHlZy0tB4glb9xQ0E. Given that both these methods involve bloating the code considerably, in comparison to what we already have with _totalPolicyCount, I propose to keep _totalPolicyCount as it is.
- Storing booleans as a single bit. (refer to https://mudit.blog/solidity-tips-and-tricks-to-save-gas-and-reduce-bytecode-size/#2a76) (My thoughts are we don’t need to use this, we are only using a single boolean storage variable (_paused) in our contract, this trick becomes useful when we want to store >32 booleans)