### PR TITLE
Refactor/soteria referral multichain

### DIFF
--- a/contracts/interfaces/products/ISolaceCoverProduct.sol
+++ b/contracts/interfaces/products/ISolaceCoverProduct.sol
@@ -275,6 +275,7 @@ interface ISolaceCoverProduct {
      * @return referralThreshold_ The referral threshold
      */
     function referralThreshold() external view returns (uint256 referralThreshold_);
+    
     /**
      * @notice Returns true if referral rewards are active, false if not.
      * @return isReferralOn_ True if referral rewards are active, false if not.

--- a/contracts/interfaces/products/ISolaceCoverProductV2.sol
+++ b/contracts/interfaces/products/ISolaceCoverProductV2.sol
@@ -71,6 +71,9 @@ interface ISolaceCoverProductV2 {
     /// @notice Emitted when referralReward is set.
     event ReferralRewardSet(uint256 referralReward);
 
+    /// @notice Emitted when referralThreshold is set.
+    event ReferralThresholdSet(uint256 referralThreshold);
+
     /// @notice Emitted when referral rewards are earned;
     event ReferralRewardsEarned(
         address rewardEarner,
@@ -192,6 +195,13 @@ interface ISolaceCoverProductV2 {
     function rewardPointsOf(address policyholder_) external view returns (uint256 rewardPoints_);
 
     /**
+     * @notice Get the total premium that a policyholder has in **USD** to 18 decimal places (does not include premium paid through reward points)
+     * @param policyholder_ The policyholder address.
+     * @return premiumsPaid_ The total premium paid for the policyholder.
+     */
+    function premiumsPaidOf(address policyholder_) external view returns (uint256 premiumsPaid_);
+
+    /**
      * @notice Gets the policyholder's policy ID.
      * @param policyholder_ The address of the policyholder.
      * @return policyID The policy ID.
@@ -276,6 +286,12 @@ interface ISolaceCoverProductV2 {
      * @return referralReward_ The referral reward
      */
     function referralReward() external view returns (uint256 referralReward_);
+
+    /**
+     * @notice Gets the threshold premium amount in USD that an account needs to have paid, for the account to be able to apply a referral code
+     * @return referralThreshold_ The referral threshold
+     */
+    function referralThreshold() external view returns (uint256 referralThreshold_);
 
     /**
      * @notice Returns true if referral rewards are active, false if not.
@@ -389,6 +405,13 @@ interface ISolaceCoverProductV2 {
      * @param referralReward_ Desired referralReward.
     */
     function setReferralReward(uint256 referralReward_) external;
+
+    /**
+     * @notice set _referralThreshhold
+     * Can only be called by the current [**governor**](/docs/protocol/governance).
+     * @param referralThreshhold_ Desired referralThreshhold.
+    */
+    function setReferralThreshold(uint256 referralThreshhold_) external;
 
     /**
      * @notice set _isReferralOn

--- a/contracts/products/SolaceCoverProduct.sol
+++ b/contracts/products/SolaceCoverProduct.sol
@@ -738,7 +738,6 @@ contract SolaceCoverProduct is
                         partialPremium
                     );
                 }
-
             }
         }
 

--- a/contracts/products/SolaceCoverProductFrax.sol
+++ b/contracts/products/SolaceCoverProductFrax.sol
@@ -1,0 +1,920 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.6;
+
+import "@openzeppelin/contracts/utils/cryptography/draft-EIP712.sol";
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "../utils/Governable.sol";
+import "../interfaces/utils/IRegistry.sol";
+import "../interfaces/risk/IRiskManager.sol";
+import "../interfaces/products/ISolaceCoverProduct.sol";
+
+/**
+ * @title SolaceCoverProduct
+ * @author solace.fi
+ * @notice A Solace insurance product that allows users to insure all of their DeFi positions against smart contract risk through a single policy.
+ *
+ * Policies can be **purchased** via [`activatePolicy()`](#activatepolicy). Policies are represented as ERC721s, which once minted, cannot then be transferred or burned. Users can change the cover limit of their policy through [`updateCoverLimit()`](#updatecoverlimit).
+ *
+ * The policy will remain active until i.) the user cancels their policy or ii.) the user's account runs out of funds. The policy will be billed like a subscription, every epoch a fee will be charged from the user's account.
+ *
+ * Users can **deposit funds** into their account via [`deposit()`](#deposit). Currently the contract only accepts deposits in **FRAX**. Note that both [`activatePolicy()`](#activatepolicy) and [`deposit()`](#deposit) enables a user to perform these actions (activate a policy, make a deposit) on behalf of another user.
+ *
+ * Users can **cancel** their policy via [`deactivatePolicy()`](#deactivatepolicy). This will start a cooldown timer. Users can **withdraw funds** from their account via [`withdraw()`](#withdraw).
+ *
+ * Before the cooldown timer starts or passes, the user cannot withdraw their entire account balance. A minimum required account balance (to cover one epoch's fee) will be left in the user's account. After the cooldown has passed, a user will be able to withdraw their entire account balance.
+ *
+ * Users can enter a **referral code** with [`activatePolicy()`](#activatePolicy) or [`updateCoverLimit()`](#updatecoverlimit). A valid referral code will earn reward points to both the referrer and the referee. When the user's account is charged, reward points will be deducted before deposited funds.
+ * Each account can only enter a valid referral code once, however there are no restrictions on how many times a referral code can be used for new accounts.
+ */
+contract SolaceCoverProductFrax is
+    ISolaceCoverProduct,
+    ERC721,
+    EIP712,
+    ReentrancyGuard,
+    Governable
+{
+    using SafeERC20 for IERC20;
+    using Address for address;
+
+    /***************************************
+    STATE VARIABLES
+    ***************************************/
+
+    /// @notice Registry contract.
+    IRegistry internal _registry;
+
+    /// @notice Cannot buy new policies while paused. (Default is False)
+    bool internal _paused;
+
+    /// @notice Referral typehash.
+    /// solhint-disable-next-line var-name-mixedcase
+    bytes32 private constant _REFERRAL_TYPEHASH = keccak256("SolaceReferral(uint256 version)");
+
+    string public baseURI;
+
+    /***************************************
+    BOOK-KEEPING VARIABLES
+    ***************************************/
+
+    /// @notice The total policy count.
+    uint256 internal _totalPolicyCount;
+
+    /**
+     * @notice The maximum rate charged per second per 1e-18 (wei) of coverLimit.
+     * @dev Default to charge 10% of cover limit annually = 1/315360000.
+     */
+    uint256 internal _maxRateNum;
+    uint256 internal _maxRateDenom;
+
+    /// @notice Maximum epoch duration over which premiums are charged (Default is one week).
+    uint256 internal _chargeCycle;
+
+    /**
+     * @notice The cooldown period (Default is one week)
+     * Cooldown timer is started by the user calling deactivatePolicy().
+     * Before the cooldown has started or has passed, withdrawing funds will leave a minimim required account balance in the user's account. Only after the cooldown has passed, is a user able to withdraw their entire account balance.
+     */
+    uint256 internal _cooldownPeriod;
+
+    /**
+     * @notice The reward points earned (to both the referee and referrer) for a valid referral code. (Default is 50 FRAX).
+     */
+    uint256 internal _referralReward;
+
+    /**
+     * @notice The threshold premium amount that an account needs to have paid, for the account to be able to apply a referral code. (Default is 100 FRAX).
+     */
+    uint256 internal _referralThreshold;
+
+    /**
+     * @notice If true, referral rewards are active. If false, referral rewards are switched off (Default is true).
+     */
+    bool internal _isReferralOn;
+
+    /**
+     * @notice policyholder => cooldown start timestamp
+     * @dev will be 0 if cooldown has not started, or has been reset
+     */
+    mapping(address => uint256) internal _cooldownStart;
+
+    /// @notice policyholder => policyID.
+    mapping(address => uint256) internal _policyOf;
+
+    /// @notice policyID => coverLimit
+    mapping(uint256 => uint256) internal _coverLimitOf;
+
+    /// @notice policyholder => premiumPaid
+    mapping(address => uint256) internal _premiumPaidOf;
+
+    /**
+     * @notice This is a mapping that no-one likes but seems necessary to circumvent a couple of edge cases. This mapping is intended to mirror the _coverLimitOf mapping, except for the period between i.) cooldown starting when deactivatePolicy() called and ii.) cooldown has passed and user calls withdraw()
+     * @dev Edge case 1: User deactivates policy -> User can withdraw all funds immediately after, circumventing the intended cooldown mechanic. This occurs because when deactivatePolicy() called, _coverLimitOf[user] is set to 0, which also sets their minRequiredAccountBalance (coverLimit * chargeCycle * maxRate) to 0.
+     * @dev Edge case 2: A user should not be able to deactivate their policy just prior to the fee charge tranasction, and then avoid the insurance fee for the current epoch.
+     * @dev will be 0 if cooldown has not started, or has been reset
+     */
+    mapping(uint256 => uint256) internal _preDeactivateCoverLimitOf;
+
+    /**
+     * @notice policyholder => reward points.
+     * Users earn reward points for using a valid referral code (as a referee), and having other users successfully use their referral code (as a referrer)
+     * Reward points can be manually set by the Cover Promotion Admin
+     * Reward points act as a credit, when an account is charged, they are deducted from before deposited funds
+     */
+    mapping(address => uint256) internal _rewardPointsOf;
+
+    /**
+     * @notice policyID => true if referral code has been used, false if not
+     * A referral code can only be used once for each policy. There is no way to reset to false.
+     */
+    mapping(uint256 => bool) internal _isReferralCodeUsed;
+
+    /// @notice policyholder => account balance (in USD, to 18 decimals places)
+    mapping(address => uint256) private _accountBalanceOf;
+
+    /***************************************
+    MODIFIERS
+    ***************************************/
+
+    modifier whileUnpaused() {
+        require(!_paused, "contract paused");
+        _;
+    }
+
+    /**
+     * @notice Constructs `Solace Cover Product`.
+     * @param governance_ The address of the governor.
+     * @param registry_ The [`Registry`](./Registry) contract address.
+     * @param domain_ The user readable name of the EIP712 signing domain.
+     * @param version_ The current major version of the signing domain.
+     */
+    constructor(
+        address governance_,
+        address registry_,
+        string memory domain_,
+        string memory version_
+    )
+        ERC721("Solace Cover Policy", "SCP")
+        Governable(governance_)
+        EIP712(domain_, version_)
+    {
+        require(registry_ != address(0x0), "zero address registry");
+        _registry = IRegistry(registry_);
+        require(_registry.get("riskManager") != address(0x0), "zero address riskmanager");
+        require(_registry.get("frax") != address(0x0), "zero address frax");
+
+        // Set default values
+        _maxRateNum = 1;
+        _maxRateDenom = 315360000; // Max premium rate of 10% of cover limit per annum
+        _chargeCycle = 604800; // One-week charge cycle
+        _cooldownPeriod = 604800; // One-week cooldown period
+        _referralReward = 50e18; // 50 FRAX
+        _referralThreshold = 100e18; // 100 FRAX
+        _isReferralOn = true; // Referral rewards active
+        baseURI = string(abi.encodePacked("https://stats.solace.fi/policy/soteria/?chainID=", Strings.toString(block.chainid), "&policyID="));
+    }
+
+    /***************************************
+    POLICYHOLDER FUNCTIONS
+    ***************************************/
+
+    /**
+     * @notice Activates policy for `policyholder_`
+     * @param policyholder_ The address of the intended policyholder.
+     * @param coverLimit_ The maximum value to cover in **USD**.
+     * @param amount_ The deposit amount in **USD** to fund the policyholder's account.
+     * @param referralCode_ The referral code.
+     * @return policyID The ID of the newly minted policy.
+     */
+    function activatePolicy(
+        address policyholder_,
+        uint256 coverLimit_,
+        uint256 amount_,
+        bytes calldata referralCode_
+    ) external override nonReentrant whileUnpaused returns (uint256 policyID) {
+        require(policyholder_ != address(0x0), "zero address policyholder");
+        require(coverLimit_ > 0, "zero cover value");
+
+        policyID = policyOf(policyholder_);
+        require(!policyStatus(policyID), "policy already activated");
+        require(_canPurchaseNewCover(0, coverLimit_), "insufficient capacity for new cover");
+        require(IERC20(_getAsset()).balanceOf(msg.sender) >= amount_, "insufficient caller balance for deposit");
+        require(amount_ + accountBalanceOf(policyholder_) > _minRequiredAccountBalance(coverLimit_), "insufficient deposit for minimum required account balance");
+
+        // Exit cooldown
+        _exitCooldown(policyholder_);
+
+        // deposit funds
+        _deposit(msg.sender, policyholder_, amount_);
+
+        // mint policy if doesn't currently exist
+        if (policyID == 0) {
+            policyID = ++_totalPolicyCount;
+            _policyOf[policyholder_] = policyID;
+            _mint(policyholder_, policyID);
+        }
+
+        _processReferralCode(policyholder_, referralCode_);
+
+        // update cover amount
+        _updateActiveCoverLimit(0, coverLimit_);
+        _coverLimitOf[policyID] = coverLimit_;
+        _preDeactivateCoverLimitOf[policyID] = coverLimit_;
+        emit PolicyCreated(policyID);
+        return policyID;
+    }
+
+    /**
+     * @notice Updates the cover limit of a user's policy.
+     * @notice This will reset the cooldown.
+     * @param newCoverLimit_ The new maximum value to cover in **USD**.
+     * @param referralCode_ The referral code.
+     */
+    function updateCoverLimit(
+        uint256 newCoverLimit_,
+        bytes calldata referralCode_
+    ) external override nonReentrant whileUnpaused {
+        require(newCoverLimit_ > 0, "zero cover value");
+        uint256 policyID = _policyOf[msg.sender];
+        require(_exists(policyID), "invalid policy");
+        uint256 currentCoverLimit = coverLimitOf(policyID);
+        require(
+            _canPurchaseNewCover(currentCoverLimit, newCoverLimit_),
+            "insufficient capacity for new cover"
+        );
+        require(
+            _accountBalanceOf[msg.sender] > _minRequiredAccountBalance(newCoverLimit_),
+            "insufficient deposit for minimum required account balance"
+        );
+
+        _processReferralCode(msg.sender, referralCode_);
+
+        _exitCooldown(msg.sender); // Reset cooldown
+        _coverLimitOf[policyID] = newCoverLimit_;
+        _preDeactivateCoverLimitOf[policyID] = newCoverLimit_;
+        _updateActiveCoverLimit(currentCoverLimit, newCoverLimit_);
+        emit PolicyUpdated(policyID);
+    }
+
+    /**
+     * @notice Deposits funds into the `policyholder` account.
+     * @param policyholder The policyholder.
+     * @param amount The amount to deposit in **USD**.
+     */
+    function deposit(
+        address policyholder,
+        uint256 amount
+    ) external override nonReentrant whileUnpaused {
+        require(policyholder != address(0x0), "zero address policyholder");
+        _deposit(msg.sender, policyholder, amount);
+    }
+
+    /**
+     * @notice Withdraw funds from user's account.
+     *
+     * @notice If cooldown has passed, the user will withdraw their entire account balance.
+     *
+     * @notice If cooldown has not started, or has not passed, the user will not be able to withdraw their entire account. A minimum required account balance (one epoch's fee) will be left in the user's account.
+     */
+    function withdraw() external override nonReentrant whileUnpaused {
+        require(_accountBalanceOf[msg.sender] > 0, "no account balance to withdraw");
+        if ( _hasCooldownPassed(msg.sender) ) {
+          _withdraw(msg.sender, _accountBalanceOf[msg.sender]);
+          _preDeactivateCoverLimitOf[_policyOf[msg.sender]] = 0;
+        } else {
+          uint256 preDeactivateCoverLimit = _preDeactivateCoverLimitOf[_policyOf[msg.sender]];
+          _withdraw(msg.sender, _accountBalanceOf[msg.sender] - _minRequiredAccountBalance(preDeactivateCoverLimit));
+        }
+    }
+
+    /**
+     * @notice Deactivate a user's policy.
+     *
+     * This will set a user's cover limit to 0, and begin the cooldown timer. Read comments for [`cooldownPeriod()`](#cooldownperiod) for more information on the cooldown mechanic.
+     */
+    function deactivatePolicy() external override nonReentrant {
+        require(policyStatus(_policyOf[msg.sender]), "invalid policy");
+        _deactivatePolicy(msg.sender);
+    }
+
+    /***************************************
+    VIEW FUNCTIONS
+    ***************************************/
+
+    /**
+     * @notice Returns the policyholder's account account balance in **USD**.
+     * @param policyholder The policyholder address.
+     * @return balance The policyholder's account balance in **USD**.
+     */
+    function accountBalanceOf(address policyholder) public view override returns (uint256 balance) {
+        return _accountBalanceOf[policyholder];
+    }
+
+    /**
+     * @notice The maximum amount of cover that can be sold in **USD** to 18 decimals places.
+     * @return cover The max amount of cover.
+     */
+    function maxCover() public view override returns (uint256 cover) {
+        return IRiskManager(_registry.get("riskManager")).maxCoverPerStrategy(address(this));
+    }
+
+    /**
+     * @notice Returns the active cover limit in **USD** to 18 decimal places. In other words, the total cover that has been sold at the current time.
+     * @return amount The active cover limit.
+     */
+    function activeCoverLimit() public view override returns (uint256 amount) {
+        return IRiskManager(_registry.get("riskManager")).activeCoverLimitPerStrategy(address(this));
+    }
+
+    /**
+     * @notice Determine the available remaining capacity for new cover.
+     * @return availableCoverCapacity_ The amount of available remaining capacity for new cover.
+     */
+    function availableCoverCapacity() public view override returns (uint256 availableCoverCapacity_) {
+        availableCoverCapacity_ = maxCover() - activeCoverLimit();
+    }
+
+    /**
+     * @notice Get the reward points that a policyholder has in **USD** to 18 decimal places.
+     * @param policyholder_ The policyholder address.
+     * @return rewardPoints_ The reward points for the policyholder.
+     */
+    function rewardPointsOf(address policyholder_) public view override returns (uint256 rewardPoints_) {
+        return _rewardPointsOf[policyholder_];
+    }
+
+    /**
+     * @notice Get the total premium that a policyholder has in **USD** to 18 decimal places (does not include premium paid through reward points)
+     * @param policyholder_ The policyholder address.
+     * @return premiumsPaid_ The total premium paid for the policyholder.
+     */
+    function premiumsPaidOf(address policyholder_) public view override returns (uint256 premiumsPaid_) {
+        return _premiumPaidOf[policyholder_];
+    }
+
+    /**
+     * @notice Gets the policyholder's policy ID.
+     * @param policyholder_ The address of the policyholder.
+     * @return policyID The policy ID.
+     */
+    function policyOf(address policyholder_) public view override returns (uint256 policyID) {
+        return _policyOf[policyholder_];
+    }
+
+    /**
+     * @notice Returns true if the policy is active, false if inactive
+     * @param policyID_ The policy ID.
+     * @return status True if policy is active. False otherwise.
+     */
+    function policyStatus(uint256 policyID_) public view override returns (bool status) {
+        return coverLimitOf(policyID_) > 0 ? true : false;
+    }
+
+    /**
+     * @notice Returns [`Registry`](./Registry) contract address.
+     * @return registry_ The `Registry` address.
+     */
+    function registry() external view override returns (address registry_) {
+        return address(_registry);
+    }
+
+    /**
+     * @notice Returns [`RiskManager`](./RiskManager) contract address.
+     * @return riskManager_ The `RiskManager` address.
+     */
+    function riskManager() external view override returns (address riskManager_) {
+        return address(_registry.get("riskManager"));
+    }
+
+    /**
+     * @notice Returns true if the product is paused, false if not.
+     * @return status True if product is paused.
+     */
+    function paused() external view override returns (bool status) {
+        return _paused;
+    }
+
+    /**
+     * @notice Gets the policy count (amount of policies that have been purchased, includes inactive policies).
+     * @return count The policy count.
+     */
+    function policyCount() public view override returns (uint256 count) {
+        return _totalPolicyCount;
+    }
+
+    /**
+     * @notice Gets the max rate numerator.
+     * @return maxRateNum_ the max rate numerator.
+     */
+    function maxRateNum() public view override returns (uint256 maxRateNum_) {
+        return _maxRateNum;
+    }
+
+    /**
+     * @notice Gets the max rate denominator.
+     * @return maxRateDenom_ the max rate denominator.
+     */
+    function maxRateDenom() public view override returns (uint256 maxRateDenom_) {
+        return _maxRateDenom;
+    }
+
+    /**
+     * @notice Gets the charge cycle duration.
+     * @return chargeCycle_ the charge cycle duration in seconds.
+     */
+    function chargeCycle() public view override returns (uint256 chargeCycle_) {
+        return _chargeCycle;
+    }
+
+    /**
+     * @notice Gets cover limit for a given policy ID.
+     * @param policyID_ The policy ID.
+     * @return amount The cover limit for given policy ID.
+     */
+    function coverLimitOf(uint256 policyID_) public view override returns (uint256 amount) {
+        return _coverLimitOf[policyID_];
+    }
+
+    /**
+     * @notice Gets the cooldown period.
+     *
+     * Cooldown timer is started by the user calling deactivatePolicy().
+     * Before the cooldown has started or has passed, withdrawing funds will leave a minimim required account balance in the user's account.
+     * Only after the cooldown has passed, is a user able to withdraw their entire account balance.
+     * @return cooldownPeriod_ The cooldown period in seconds.
+     */
+    function cooldownPeriod() external view override returns (uint256 cooldownPeriod_) {
+        return _cooldownPeriod;
+    }
+
+    /**
+     * @notice The Unix timestamp that a policyholder's cooldown started. If cooldown has not started or has been reset, will return 0.
+     * @param policyholder_ The policyholder address
+     * @return cooldownStart_ The cooldown period start expressed as Unix timestamp
+     */
+    function cooldownStart(address policyholder_) external view override returns (uint256 cooldownStart_) {
+        return _cooldownStart[policyholder_];
+    }
+
+    /**
+     * @notice Gets the current reward amount in USD for a valid referral code.
+     * @return referralReward_ The referral reward
+     */
+    function referralReward() external view override returns (uint256 referralReward_) {
+        return _referralReward;
+    }
+
+    /**
+     * @notice Gets the threshold premium amount in USD that an account needs to have paid, for the account to be able to apply a referral code
+     * @return referralThreshold_ The referral threshold
+     */
+    function referralThreshold() external view override returns (uint256 referralThreshold_) {
+        return _referralThreshold;
+    }
+
+    /**
+     * @notice Returns true if referral rewards are active, false if not.
+     * @return isReferralOn_ True if referral rewards are active, false if not.
+     */
+    function isReferralOn() external view override returns (bool isReferralOn_) {
+        return _isReferralOn;
+    }
+
+    /**
+     * @notice True if a policyholder has previously used a valid referral code, false if not
+     *
+     * A policyholder can only use a referral code once. A policyholder is then ineligible to receive further rewards from additional referral codes.
+     * @return isReferralCodeUsed_ True if the policyholder has previously used a valid referral code, false if not
+     */
+    function isReferralCodeUsed(address policyholder) external view override returns (bool isReferralCodeUsed_) {
+        return _isReferralCodeUsed[_policyOf[policyholder]];
+    }
+
+    /**
+     * @notice Returns true if valid referral code, false otherwise.
+     * @param referralCode The referral code.
+     */
+    function isReferralCodeValid(bytes calldata referralCode) external view override returns (bool) {
+        (address referrer,) = ECDSA.tryRecover(_getEIP712Hash(), referralCode);
+        if(referrer == address(0)) return false;
+        return true;
+    }
+
+    /**
+     * @notice Get referrer from referral code, returns 0 address if invalid referral code.
+     * @param referralCode The referral code.
+     * @return referrer The referrer address, returns 0 address if invalid referral code.
+     */
+    function getReferrerFromReferralCode(bytes calldata referralCode) external view override returns (address referrer) {
+        (referrer,) = ECDSA.tryRecover(_getEIP712Hash(), referralCode);
+    }
+
+    /**
+     * @notice Calculate minimum required account balance for a given cover limit. Equals the maximum chargeable fee for one epoch.
+     * @param coverLimit Cover limit.
+     */
+    function minRequiredAccountBalance(uint256 coverLimit) external view override returns (uint256 minRequiredAccountBalance_) {
+        return _minRequiredAccountBalance(coverLimit);
+    }
+
+    /**
+     * @notice Returns the Uniform Resource Identifier (URI) for `policyID`.
+     * @param policyID The policy ID.
+     */
+    function tokenURI(uint256 policyID) public view virtual override returns (string memory tokenURI_) {
+        require(_exists(policyID), "invalid policy");
+        string memory baseURI_ = baseURI;
+        return string(abi.encodePacked( baseURI_, Strings.toString(policyID) ));
+    }
+
+    /***************************************
+    GOVERNANCE FUNCTIONS
+    ***************************************/
+
+    /**
+     * @notice Sets the [`Registry`](./Registry) contract address.
+     * Can only be called by the current [**governor**](/docs/protocol/governance).
+     * @param registry_ The address of `Registry` contract.
+     */
+    function setRegistry(address registry_) external override onlyGovernance {
+        require(registry_ != address(0x0), "zero address registry");
+        _registry = IRegistry(registry_);
+
+        require(_registry.get("riskManager") != address(0x0), "zero address riskmanager");
+        require(_registry.get("frax") != address(0x0), "zero address frax");
+        emit RegistrySet(registry_);
+    }
+
+    /**
+     * @notice Pauses or unpauses policies.
+     * Deactivating policies are unaffected by pause.
+     * Can only be called by the current [**governor**](/docs/protocol/governance).
+     * @param paused_ True to pause, false to unpause.
+     */
+    function setPaused(bool paused_) external override onlyGovernance {
+        _paused = paused_;
+        emit PauseSet(paused_);
+    }
+
+    /**
+     * @notice Sets the cooldown period. Read comments for [`cooldownPeriod()`](#cooldownperiod) for more information on the cooldown mechanic.
+     * Can only be called by the current [**governor**](/docs/protocol/governance).
+     * @param cooldownPeriod_ Cooldown period in seconds.
+     */
+    function setCooldownPeriod(uint256 cooldownPeriod_) external override onlyGovernance {
+        _cooldownPeriod = cooldownPeriod_;
+        emit CooldownPeriodSet(cooldownPeriod_);
+    }
+
+    /**
+     * @notice set _maxRateNum.
+     * Can only be called by the current [**governor**](/docs/protocol/governance).
+     * @param maxRateNum_ Desired maxRateNum.
+     */
+    function setMaxRateNum(uint256 maxRateNum_) external override onlyGovernance {
+        _maxRateNum = maxRateNum_;
+        emit MaxRateNumSet(maxRateNum_);
+    }
+
+    /**
+     * @notice set _maxRateDenom.
+     * Can only be called by the current [**governor**](/docs/protocol/governance).
+     * @param maxRateDenom_ Desired maxRateDenom.
+     */
+    function setMaxRateDenom(uint256 maxRateDenom_) external override onlyGovernance {
+        _maxRateDenom = maxRateDenom_;
+        emit MaxRateDenomSet(maxRateDenom_);
+    }
+
+    /**
+     * @notice set _chargeCycle.
+     * Can only be called by the current [**governor**](/docs/protocol/governance).
+     * @param chargeCycle_ Desired chargeCycle.
+     */
+    function setChargeCycle(uint256 chargeCycle_) external override onlyGovernance {
+        _chargeCycle = chargeCycle_;
+        emit ChargeCycleSet(chargeCycle_);
+    }
+
+    /**
+     * @notice set _referralReward
+     * Can only be called by the current [**governor**](/docs/protocol/governance).
+     * @param referralReward_ Desired referralReward.
+    */
+    function setReferralReward(uint256 referralReward_) external override onlyGovernance {
+        _referralReward = referralReward_;
+        emit ReferralRewardSet(referralReward_);
+    }
+
+    /**
+     * @notice set _referralThreshhold
+     * Can only be called by the current [**governor**](/docs/protocol/governance).
+     * @param referralThreshhold_ Desired referralThreshhold.
+    */
+    function setReferralThreshold(uint256 referralThreshhold_) external override onlyGovernance {
+        _referralThreshold = referralThreshhold_;
+        emit ReferralThresholdSet(referralThreshhold_);
+    }
+
+    /**
+     * @notice set _isReferralOn
+     * Can only be called by the current [**governor**](/docs/protocol/governance).
+     * @param isReferralOn_ True if referral rewards active, false if not.
+    */
+    function setIsReferralOn(bool isReferralOn_) external override onlyGovernance {
+        _isReferralOn = isReferralOn_;
+        emit IsReferralOnSet(isReferralOn_);
+    }
+
+    /**
+     * @notice Sets the base URI for computing `tokenURI`.
+     * @param baseURI_ The new base URI.
+     */
+    function setBaseURI(string memory baseURI_) external override onlyGovernance {
+        baseURI = baseURI_;
+        emit BaseURISet(baseURI_);
+    }
+
+    /***************************************
+    COVER PROMOTION ADMIN FUNCTIONS
+    ***************************************/
+
+    /**
+     * @notice Set reward points for a selected address. Can only be called by the **Cover Promotion Admin** role.
+     * @param policyholder_ The address of the policyholder to set reward points for.
+     * @param rewardPoints_ Desired amount of reward points.
+     */
+    function setRewardPoints(address policyholder_, uint256 rewardPoints_) external override {
+        require(msg.sender == _registry.get("coverPromotionAdmin"), "not cover promotion admin");
+        _rewardPointsOf[policyholder_] = rewardPoints_;
+        emit RewardPointsSet(policyholder_, rewardPoints_);
+    }
+
+    /***************************************
+    PREMIUM COLLECTOR FUNCTIONS
+    ***************************************/
+
+    /**
+     * @notice Charge premiums for each policy holder. Can only be called by the **Premium Collector** role.
+     *
+     * @dev Cheaper to load variables directly from calldata, rather than adding an additional operation of copying to memory.
+     * @param holders Array of addresses of the policyholders to charge.
+     * @param premiums Array of premium amounts (in **USD** to 18 decimal places) to charge each policyholder.
+     */
+    function chargePremiums(
+        address[] calldata holders,
+        uint256[] calldata premiums
+    ) external override whileUnpaused {
+        uint256 count = holders.length;
+        require(msg.sender == _registry.get("premiumCollector"), "not premium collector");
+        require(count == premiums.length, "length mismatch");
+        require(count <= policyCount(), "policy count exceeded");
+        uint256 amountToPayPremiumPool = 0;
+
+        for (uint256 i = 0; i < count; i++) {
+            // Skip computation if the user has withdrawn entire account balance
+            // We use _preDeactivateCoverLimitOf mapping here to circumvent the following edge case: A user should not be able to deactivate their policy just prior to the chargePremiums() tranasction, and then avoid the premium for the current epoch.
+            // There is another edge case introduced here however: the premium collector can charge a deactivated account more than once. We are trusting that the premium collector does not do this.
+
+            uint256 preDeactivateCoverLimit = _preDeactivateCoverLimitOf[_policyOf[holders[i]]];
+            if ( preDeactivateCoverLimit == 0) continue;
+
+            uint256 premium = premiums[i];
+            if (premiums[i] > _minRequiredAccountBalance(preDeactivateCoverLimit)) {
+                premium = _minRequiredAccountBalance(preDeactivateCoverLimit);
+            }
+
+            // If policyholder's account can pay for premium charged in full
+            if (_accountBalanceOf[holders[i]] + _rewardPointsOf[holders[i]] >= premium) {
+
+                // If reward points can pay for premium charged in full
+                if (_rewardPointsOf[holders[i]] >= premium) {
+                    _rewardPointsOf[holders[i]] -= premium;
+                } else {
+                    uint256 amountDeductedFromSoteriaAccount = premium - _rewardPointsOf[holders[i]];
+                    amountToPayPremiumPool += amountDeductedFromSoteriaAccount;
+                    _premiumPaidOf[holders[i]] += amountDeductedFromSoteriaAccount;
+                    _accountBalanceOf[holders[i]] -= amountDeductedFromSoteriaAccount;
+                    _rewardPointsOf[holders[i]] = 0;
+                }
+                emit PremiumCharged(holders[i], premium);
+            } else {
+                uint256 partialPremium = _accountBalanceOf[holders[i]] + _rewardPointsOf[holders[i]];
+                amountToPayPremiumPool += _accountBalanceOf[holders[i]];
+                _premiumPaidOf[holders[i]] += _accountBalanceOf[holders[i]];
+                _accountBalanceOf[holders[i]] = 0;
+                _rewardPointsOf[holders[i]] = 0;
+                _deactivatePolicy(holders[i]);
+                emit PremiumPartiallyCharged(
+                    holders[i],
+                    premium,
+                    partialPremium
+                );
+            }
+        }
+
+        // single FRAX transfer to the premium pool
+        SafeERC20.safeTransfer(_getAsset(), _registry.get("premiumPool"), amountToPayPremiumPool);
+    }
+
+    /***************************************
+    INTERNAL FUNCTIONS
+    ***************************************/
+
+    /**
+     * @notice Returns true if there is sufficient capacity to update a policy's cover limit, false if not.
+     * @param existingTotalCover_ The current cover limit, 0 if policy has not previously been activated.
+     * @param newTotalCover_  The new cover limit requested.
+     * @return acceptable True there is sufficient capacity for the requested new cover limit, false otherwise.
+     */
+    function _canPurchaseNewCover(
+        uint256 existingTotalCover_,
+        uint256 newTotalCover_
+    ) internal view returns (bool acceptable) {
+        if (newTotalCover_ <= existingTotalCover_) return true; // Return if user is lowering cover limit
+        uint256 changeInTotalCover = newTotalCover_ - existingTotalCover_; // This will revert if newTotalCover_ < existingTotalCover_
+        if (changeInTotalCover < availableCoverCapacity()) return true;
+        else return false;
+    }
+
+    /**
+     * @notice Deposits funds into the policyholder's account balance.
+     * @param from The address which is funding the deposit.
+     * @param policyholder The policyholder address.
+     * @param amount The deposit amount in **USD** to 18 decimal places.
+     */
+    function _deposit(
+        address from,
+        address policyholder,
+        uint256 amount
+    ) internal whileUnpaused {
+        SafeERC20.safeTransferFrom(_getAsset(), from, address(this), amount);
+        _accountBalanceOf[policyholder] += amount;
+        emit DepositMade(from, policyholder, amount);
+    }
+
+    /**
+     * @notice Withdraw funds from policyholder's account to the policyholder.
+     * @param policyholder The policyholder address.
+     * @param amount The amount to withdraw in **USD** to 18 decimal places.
+     */
+    function _withdraw(
+        address policyholder,
+        uint256 amount
+    ) internal whileUnpaused {
+        SafeERC20.safeTransfer(_getAsset(), policyholder, amount);
+        _accountBalanceOf[policyholder] -= amount;
+        emit WithdrawMade(policyholder, amount);
+    }
+
+    /**
+     * @notice Deactivate the policy.
+     * @param policyholder The policyholder address.
+     */
+    function _deactivatePolicy(address policyholder) internal {
+        _startCooldown(policyholder);
+        uint256 policyID = _policyOf[policyholder];
+        _updateActiveCoverLimit(_coverLimitOf[policyID], 0);
+        _coverLimitOf[policyID] = 0;
+        emit PolicyDeactivated(policyID);
+    }
+
+    /**
+     * @notice Updates the Risk Manager on the current total cover limit purchased by policyholders.
+     * @param currentCoverLimit The current policyholder cover limit (0 if activating policy).
+     * @param newCoverLimit The new policyholder cover limit.
+     */
+    function _updateActiveCoverLimit(
+        uint256 currentCoverLimit,
+        uint256 newCoverLimit
+    ) internal {
+        IRiskManager(_registry.get("riskManager"))
+            .updateActiveCoverLimitForStrategy(
+                address(this),
+                currentCoverLimit,
+                newCoverLimit
+            );
+    }
+
+    /**
+     * @notice Calculate minimum required account balance for a given cover limit. Equals the maximum chargeable fee for one epoch.
+     * @param coverLimit Cover limit.
+     */
+    function _minRequiredAccountBalance(uint256 coverLimit) internal view returns (uint256 minRequiredAccountBalance) {
+        minRequiredAccountBalance = (_maxRateNum * _chargeCycle * coverLimit) / _maxRateDenom;
+    }
+
+    /**
+     * @notice Override _beforeTokenTransfer hook from ERC721 standard to ensure policies are non-transferable, and only one can be minted per user.
+     * @dev This hook is called on mint, transfer and burn.
+     * @param from sending address.
+     * @param to receiving address.
+     * @param tokenId tokenId.
+     */
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual override {
+        super._beforeTokenTransfer(from, to, tokenId);
+        require(from == address(0), "only minting permitted");
+    }
+
+    /**
+     * @notice Starts the cooldown period for the policyholder.
+     * @param policyholder Policyholder address.
+     */
+    function _startCooldown(address policyholder) internal {
+        // solhint-disable-next-line not-rely-on-time
+        _cooldownStart[policyholder] = block.timestamp;
+        emit CooldownStarted(policyholder, _cooldownStart[policyholder]);
+    }
+
+    /**
+     * @notice Exits the cooldown period for a policyholder.
+     * @param policyholder Policyholder address.
+     */
+    function _exitCooldown(address policyholder) internal {
+        _cooldownStart[policyholder] = 0;
+        emit CooldownStopped(policyholder);
+    }
+
+    /**
+     * @notice Return true if cooldown has passed for a policyholder, false if cooldown has not started or has not passed.
+     * @param policyholder Policyholder address.
+     * @return True if cooldown has passed, false if cooldown has not started or has not passed.
+     */
+    function _hasCooldownPassed(address policyholder) internal view returns (bool) {
+        if (_cooldownStart[policyholder] == 0) {
+            return false;
+        } else {
+            // solhint-disable-next-line not-rely-on-time
+            return block.timestamp >= _cooldownStart[policyholder] + _cooldownPeriod;
+        }
+    }
+
+    /**
+     * @notice Internal function to process a referral code
+     * @param policyholder_ Policyholder address.
+     * @param referralCode_ Referral code.
+     */
+    function _processReferralCode(
+        address policyholder_,
+        bytes calldata referralCode_
+    ) internal {
+        // Skip processing referral code, if referral campaign switched off or empty referral code argument
+        if ( !_isReferralOn || _isEmptyReferralCode(referralCode_) ) return;
+
+        require(_premiumPaidOf[policyholder_] >= _referralThreshold, "cannot apply referral code if premium paid < referralThreshold");
+
+        address referrer = ECDSA.recover(_getEIP712Hash(), referralCode_);
+        require(referrer != policyholder_, "cannot refer to self");
+        require(policyStatus(_policyOf[referrer]), "referrer must be active policy holder");
+        require (!_isReferralCodeUsed[_policyOf[policyholder_]], "cannot use referral code again");
+
+        _isReferralCodeUsed[_policyOf[policyholder_]] = true;
+        _rewardPointsOf[policyholder_] += _referralReward;
+        _rewardPointsOf[referrer] += _referralReward;
+
+        emit ReferralRewardsEarned(policyholder_, _referralReward);
+        emit ReferralRewardsEarned(referrer, _referralReward);
+    }
+
+    /**
+     * @notice Internal helper function to determine if referralCode_ is an empty bytes value
+     * @param referralCode_ Referral code.
+     * @return True if empty referral code, false if not.
+     */
+    function _isEmptyReferralCode(bytes calldata referralCode_) internal pure returns (bool) {
+        return (keccak256(abi.encodePacked(referralCode_)) == keccak256(abi.encodePacked("")));
+    }
+
+    /**
+     * @notice Internal helper function to get EIP712-compliant hash for referral code verification.
+     */
+    function _getEIP712Hash() internal view returns (bytes32) {
+        bytes32 digest =
+            ECDSA.toTypedDataHash(
+                _domainSeparatorV4(),
+                keccak256(
+                    abi.encode(
+                        _REFERRAL_TYPEHASH,
+                        1
+                    )
+                )
+            );
+        return digest;
+    }
+
+    /**
+     * @notice Returns the underlying principal asset for `Solace Cover Product`.
+     * @return asset The underlying asset.
+    */
+    function _getAsset() internal view returns (IERC20 asset) {
+        return IERC20(_registry.get("frax"));
+    }
+}

--- a/contracts/products/SolaceCoverProductV2.sol
+++ b/contracts/products/SolaceCoverProductV2.sol
@@ -92,6 +92,11 @@ contract SolaceCoverProductV2 is
     uint256 internal _referralReward;
 
     /**
+     * @notice The threshold premium amount that an account needs to have paid, for the account to be able to apply a referral code. (Default is 100 FRAX).
+     */
+    uint256 internal _referralThreshold;
+
+    /**
      * @notice If true, referral rewards are active. If false, referral rewards are switched off (Default is true).
      */
     bool internal _isReferralOn;
@@ -107,6 +112,9 @@ contract SolaceCoverProductV2 is
 
     /// @notice policyID => coverLimit
     mapping(uint256 => uint256) internal _coverLimitOf;
+
+    /// @notice policyholder => premiumPaid
+    mapping(address => uint256) internal _premiumPaidOf;
 
     /**
      * @notice This is a mapping that no-one likes but seems necessary to circumvent a couple of edge cases. This mapping is intended to mirror the _coverLimitOf mapping, except for the period between i.) cooldown starting when deactivatePolicy() called and ii.) cooldown has passed and user calls withdraw()
@@ -178,6 +186,7 @@ contract SolaceCoverProductV2 is
         _chargeCycle = 604800; // One-week charge cycle
         _cooldownPeriod = 604800; // One-week cooldown period
         _referralReward = 50e18; // 50 FRAX
+        _referralThreshold = 100e18; // 100 FRAX
         _isReferralOn = true; // Referral rewards active
         asset = asset_;
         baseURI = string(abi.encodePacked("https://stats.solace.fi/policy/?chainID=", Strings.toString(block.chainid), "&policyID="));
@@ -369,6 +378,15 @@ contract SolaceCoverProductV2 is
     }
 
     /**
+     * @notice Get the total premium that a policyholder has in **USD** to 18 decimal places (does not include premium paid through reward points)
+     * @param policyholder_ The policyholder address.
+     * @return premiumsPaid_ The total premium paid for the policyholder.
+     */
+    function premiumsPaidOf(address policyholder_) public view override returns (uint256 premiumsPaid_) {
+        return _premiumPaidOf[policyholder_];
+    }
+
+    /**
      * @notice Gets the policyholder's policy ID.
      * @param policyholder_ The address of the policyholder.
      * @return policyID The policy ID.
@@ -478,6 +496,14 @@ contract SolaceCoverProductV2 is
      */
     function referralReward() external view override returns (uint256 referralReward_) {
         return _referralReward;
+    }
+
+    /**
+     * @notice Gets the threshold premium amount in USD that an account needs to have paid, for the account to be able to apply a referral code
+     * @return referralThreshold_ The referral threshold
+     */
+    function referralThreshold() external view override returns (uint256 referralThreshold_) {
+        return _referralThreshold;
     }
 
     /**
@@ -649,6 +675,16 @@ contract SolaceCoverProductV2 is
     }
 
     /**
+     * @notice set _referralThreshhold
+     * Can only be called by the current [**governor**](/docs/protocol/governance).
+     * @param referralThreshhold_ Desired referralThreshhold.
+    */
+    function setReferralThreshold(uint256 referralThreshhold_) external override onlyGovernance {
+        _referralThreshold = referralThreshhold_;
+        emit ReferralThresholdSet(referralThreshhold_);
+    }
+
+    /**
      * @notice set _isReferralOn
      * Can only be called by the current [**governor**](/docs/protocol/governance).
      * @param isReferralOn_ True if referral rewards active, false if not.
@@ -736,7 +772,7 @@ contract SolaceCoverProductV2 is
             // Skip computation if the user has withdrawn entire account balance
             // We use _preDeactivateCoverLimitOf mapping here to circumvent the following edge case: A user should not be able to deactivate their policy just prior to the chargePremiums() tranasction, and then avoid the premium for the current epoch.
             // There is another edge case introduced here however: the premium collector can charge a deactivated account more than once. We are trusting that the premium collector does not do this.
-            
+
             uint256 preDeactivateCoverLimit = _preDeactivateCoverLimitOf[_policyOf[holders[i]]];
             if ( preDeactivateCoverLimit == 0) continue;
 
@@ -745,33 +781,58 @@ contract SolaceCoverProductV2 is
                 premium = _minRequiredAccountBalance(preDeactivateCoverLimit);
             }
 
-            // If policyholder's account can pay for premium charged in full
-            if (_accountBalanceOf[holders[i]] + _rewardPointsOf[holders[i]] >= premium) {
-                
-                // If reward points can pay for premium charged in full
-                if (_rewardPointsOf[holders[i]] >= premium) {
-                    _rewardPointsOf[holders[i]] -= premium;
+            // If premiums paid >= referralThreshold, then reward points count
+            if (_premiumPaidOf[holders[i]] >= _referralThreshold) {
+                // If policyholder's account can pay for premium charged in full
+                if (_accountBalanceOf[holders[i]] + _rewardPointsOf[holders[i]] >= premium) {
+
+                    // If reward points can pay for premium charged in full
+                    if (_rewardPointsOf[holders[i]] >= premium) {
+                        _rewardPointsOf[holders[i]] -= premium;
+                    } else {
+                        uint256 amountDeductedFromSoteriaAccount = premium - _rewardPointsOf[holders[i]];
+                        amountToPayPremiumPool += amountDeductedFromSoteriaAccount;
+                        _premiumPaidOf[holders[i]] += amountDeductedFromSoteriaAccount;
+                        _accountBalanceOf[holders[i]] -= amountDeductedFromSoteriaAccount;
+                        _rewardPointsOf[holders[i]] = 0;
+                    }
+                    emit PremiumCharged(holders[i], premium);
                 } else {
-                    uint256 amountDeductedFromSoteriaAccount = premium - _rewardPointsOf[holders[i]];
-                    amountToPayPremiumPool += amountDeductedFromSoteriaAccount;
-                    _accountBalanceOf[holders[i]] -= amountDeductedFromSoteriaAccount;
+                    uint256 partialPremium = _accountBalanceOf[holders[i]] + _rewardPointsOf[holders[i]];
+                    amountToPayPremiumPool += _accountBalanceOf[holders[i]];
+                    _premiumPaidOf[holders[i]] += _accountBalanceOf[holders[i]]; 
+                    _accountBalanceOf[holders[i]] = 0;
                     _rewardPointsOf[holders[i]] = 0;
+                    _deactivatePolicy(holders[i]);
+                    emit PremiumPartiallyCharged(
+                        holders[i],
+                        premium,
+                        partialPremium
+                    );
                 }
-                emit PremiumCharged(holders[i], premium);
+            // Else if premiums paid < referralThreshold, reward don't count
             } else {
-                uint256 partialPremium = _accountBalanceOf[holders[i]] + _rewardPointsOf[holders[i]];
-                amountToPayPremiumPool += _accountBalanceOf[holders[i]];
-                _accountBalanceOf[holders[i]] = 0;
-                _rewardPointsOf[holders[i]] = 0;
-                _deactivatePolicy(holders[i]);
-                emit PremiumPartiallyCharged(
-                    holders[i],
-                    premium,
-                    partialPremium
-                );
+                // If policyholder's account can pay for premium charged in full
+                if (_accountBalanceOf[holders[i]] >= premium) {
+                        amountToPayPremiumPool += premium;
+                        _premiumPaidOf[holders[i]] += premium;
+                        _accountBalanceOf[holders[i]] -= premium;
+                        emit PremiumCharged(holders[i], premium);   
+                } else {
+                    uint256 partialPremium = _accountBalanceOf[holders[i]];
+                    amountToPayPremiumPool += partialPremium;
+                    _premiumPaidOf[holders[i]] += partialPremium; 
+                    _accountBalanceOf[holders[i]] = 0;
+                    _deactivatePolicy(holders[i]);
+                    emit PremiumPartiallyCharged(
+                        holders[i],
+                        premium,
+                        partialPremium
+                    );
+                }
             }
         }
-  
+
         // single FRAX transfer to the premium pool
         SafeERC20.safeTransfer(_getAsset(), _registry.get("premiumPool"), amountToPayPremiumPool);
     }

--- a/test/products/SolaceCoverProduct.test.ts
+++ b/test/products/SolaceCoverProduct.test.ts
@@ -616,36 +616,16 @@ describe("SolaceCoverProduct", function() {
             // Deactivate policyholder3 account (so we can repeat activatePolicy in subsequent tests)
             await solaceCoverProduct.connect(policyholder3).deactivatePolicy();
         })
-        // it("cannot use a referral code, if premiumPaid < 100", async () => {
-        //     const referralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
-        //     expect(await solaceCoverProduct.premiumsPaidOf(policyholder1.address)).eq(0)
-        //     await expect(solaceCoverProduct.connect(policyholder1).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, INITIAL_DEPOSIT, referralCode)).to.revertedWith("cannot apply referral code if premium paid < referralThreshold")
-        // })
         it("cannot use own referral code", async () => {
-            // Temporary state change just for this state, set premiumPaidOf(policyholder3) = 100
-            // await manipulatePremiumPaidOf(policyholder3, REFERRAL_THRESHOLD)
-            
             // Create new wallet just for this unit test scope, to avoid creating side effects that impact other unit tests. It's a headfuck to work that out.
             const ownReferralCode = await getSolaceReferralCode(policyholder3, solaceCoverProduct)
             await expect(solaceCoverProduct.connect(governor).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, INITIAL_DEPOSIT, ownReferralCode)).to.revertedWith("cannot refer to self");
-
-            // await manipulatePremiumPaidOf(policyholder3, BN.from(0))
-            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder3.address)).eq(0)
         })
         it("cannot use an invalid referral code", async () => {
-            // Temporary state change just for this state, set premiumPaidOf(policyholder3) = 100
-            // await manipulatePremiumPaidOf(policyholder3, REFERRAL_THRESHOLD)
-
             await expect(solaceCoverProduct.connect(governor).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, INITIAL_DEPOSIT, FAKE_REFERRAL_CODE)).to.revertedWith("ECDSA: invalid signature 's' value")
-
-            // await manipulatePremiumPaidOf(policyholder3, BN.from(0))
-            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder3.address)).eq(0)
         })
 
         it("can use referral code only once", async () => {
-            // Temporary state change just for this state, set premiumPaidOf(policyholder3) = 100
-            // await manipulatePremiumPaidOf(policyholder3, REFERRAL_THRESHOLD)
-
             let referralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
             
             let tx = await solaceCoverProduct.connect(governor).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, INITIAL_DEPOSIT, referralCode);
@@ -665,8 +645,6 @@ describe("SolaceCoverProduct", function() {
             await solaceCoverProduct.connect(coverPromotionAdmin).setRewardPoints(policyholder3.address, 0);
             expect(await solaceCoverProduct.rewardPointsOf(policyholder1.address)).eq(0)
             expect(await solaceCoverProduct.rewardPointsOf(policyholder3.address)).eq(0)
-            // await manipulatePremiumPaidOf(policyholder3, BN.from(0))
-            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder3.address)).eq(0)
         })
     });
 
@@ -816,43 +794,20 @@ describe("SolaceCoverProduct", function() {
             await solaceCoverProduct.connect(policyholder1).updateCoverLimit(initialCoverLimit, []);
             expect (await solaceCoverProduct.cooldownStart(policyholder1.address)).eq(0)
         })
-        // it("cannot use a referral code, if premiumPaid < 100", async () => {
-        //     let referralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
-        //     let coverLimit = await solaceCoverProduct.coverLimitOf(POLICY_ID_2);
-        //     await expect(solaceCoverProduct.connect(policyholder2).updateCoverLimit(coverLimit, referralCode)).to.revertedWith("cannot apply referral code if premium paid < referralThreshold")
-        // })
         it("cannot use invalid referral code", async () => {
-            // Temporary state change just for this state, set premiumPaidOf(policyholder1) = 100
-            // await manipulatePremiumPaidOf(policyholder1, REFERRAL_THRESHOLD)
-            
             let coverLimit = await solaceCoverProduct.coverLimitOf(POLICY_ID_1);
             await expect(solaceCoverProduct.connect(policyholder1).updateCoverLimit(coverLimit, FAKE_REFERRAL_CODE)).to.be.reverted;
-
-            // await manipulatePremiumPaidOf(policyholder1, BN.from(0))
-            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder1.address)).eq(0)
         })
         it("cannot use own referral code", async () => {
-            // Temporary state change just for this state, set premiumPaidOf(policyholder1) = 100
-            // await manipulatePremiumPaidOf(policyholder1, REFERRAL_THRESHOLD)
-
             let ownReferralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
             let coverLimit = await solaceCoverProduct.coverLimitOf(POLICY_ID_1);
             await expect(solaceCoverProduct.connect(policyholder1).updateCoverLimit(coverLimit, ownReferralCode)).to.revertedWith("cannot refer to self");
-
-            // await manipulatePremiumPaidOf(policyholder1, BN.from(0))
-            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder1.address)).eq(0)
         })
         it("cannot use referral code of an inactive policy holder", async () => {
-            // Temporary state change just for this state, set premiumPaidOf(policyholder2) = 100
-            // await manipulatePremiumPaidOf(policyholder2, REFERRAL_THRESHOLD)
-
             expect(await solaceCoverProduct.policyStatus(POLICY_ID_3)).eq(false)
             let referralCode = await getSolaceReferralCode(policyholder3, solaceCoverProduct)
             let coverLimit = await solaceCoverProduct.coverLimitOf(POLICY_ID_2);
             await expect(solaceCoverProduct.connect(policyholder2).updateCoverLimit(coverLimit, referralCode)).to.revertedWith("referrer must be active policy holder");
-
-            // await manipulatePremiumPaidOf(policyholder2, BN.from(0))
-            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder2.address)).eq(0)
         })
         it("will not give reward points if isReferralOn == false", async () => {
             // Set isReferralOn to false
@@ -875,9 +830,6 @@ describe("SolaceCoverProduct", function() {
             expect(await solaceCoverProduct.isReferralOn()).eq(true)
         })
         it("can use referral code only once", async () => {
-            // Temporary state change just for this state, set premiumPaidOf(policyholder2) = 100
-            // await manipulatePremiumPaidOf(policyholder2, REFERRAL_THRESHOLD)
-
             let referralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
             let coverLimit = await solaceCoverProduct.coverLimitOf(POLICY_ID_2);
             expect(await solaceCoverProduct.isReferralCodeUsed(policyholder2.address)).eq(false)
@@ -900,8 +852,6 @@ describe("SolaceCoverProduct", function() {
             await solaceCoverProduct.connect(coverPromotionAdmin).setRewardPoints(policyholder2.address, 0);
             expect(await solaceCoverProduct.rewardPointsOf(policyholder1.address)).eq(0)
             expect(await solaceCoverProduct.rewardPointsOf(policyholder2.address)).eq(0)
-            // await manipulatePremiumPaidOf(policyholder2, BN.from(0))
-            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder2.address)).eq(0)
         })
     });
 
@@ -1249,6 +1199,7 @@ describe("SolaceCoverProduct", function() {
             // Policy 2: reward points can partially pay for premium, rest will come from account balance
             // Policy 3: reward points + account balance unable to fully pay for premium
 
+            // Need to manipuate premium paid to be >= 100, so reward points count in chargePremiums() computation
             await manipulatePremiumPaidOf(policyholder1, REFERRAL_THRESHOLD)
             await manipulatePremiumPaidOf(policyholder2, REFERRAL_THRESHOLD)
             await manipulatePremiumPaidOf(policyholder3, REFERRAL_THRESHOLD)

--- a/test/products/SolaceCoverProduct.test.ts
+++ b/test/products/SolaceCoverProduct.test.ts
@@ -616,35 +616,35 @@ describe("SolaceCoverProduct", function() {
             // Deactivate policyholder3 account (so we can repeat activatePolicy in subsequent tests)
             await solaceCoverProduct.connect(policyholder3).deactivatePolicy();
         })
-        it("cannot use a referral code, if premiumPaid < 100", async () => {
-            const referralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
-            expect(await solaceCoverProduct.premiumsPaidOf(policyholder1.address)).eq(0)
-            await expect(solaceCoverProduct.connect(policyholder1).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, INITIAL_DEPOSIT, referralCode)).to.revertedWith("cannot apply referral code if premium paid < referralThreshold")
-        })
+        // it("cannot use a referral code, if premiumPaid < 100", async () => {
+        //     const referralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
+        //     expect(await solaceCoverProduct.premiumsPaidOf(policyholder1.address)).eq(0)
+        //     await expect(solaceCoverProduct.connect(policyholder1).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, INITIAL_DEPOSIT, referralCode)).to.revertedWith("cannot apply referral code if premium paid < referralThreshold")
+        // })
         it("cannot use own referral code", async () => {
             // Temporary state change just for this state, set premiumPaidOf(policyholder3) = 100
-            await manipulatePremiumPaidOf(policyholder3, REFERRAL_THRESHOLD)
+            // await manipulatePremiumPaidOf(policyholder3, REFERRAL_THRESHOLD)
             
             // Create new wallet just for this unit test scope, to avoid creating side effects that impact other unit tests. It's a headfuck to work that out.
             const ownReferralCode = await getSolaceReferralCode(policyholder3, solaceCoverProduct)
             await expect(solaceCoverProduct.connect(governor).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, INITIAL_DEPOSIT, ownReferralCode)).to.revertedWith("cannot refer to self");
 
-            await manipulatePremiumPaidOf(policyholder3, BN.from(0))
-            expect(await solaceCoverProduct.premiumsPaidOf(policyholder3.address)).eq(0)
+            // await manipulatePremiumPaidOf(policyholder3, BN.from(0))
+            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder3.address)).eq(0)
         })
         it("cannot use an invalid referral code", async () => {
             // Temporary state change just for this state, set premiumPaidOf(policyholder3) = 100
-            await manipulatePremiumPaidOf(policyholder3, REFERRAL_THRESHOLD)
+            // await manipulatePremiumPaidOf(policyholder3, REFERRAL_THRESHOLD)
 
             await expect(solaceCoverProduct.connect(governor).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, INITIAL_DEPOSIT, FAKE_REFERRAL_CODE)).to.revertedWith("ECDSA: invalid signature 's' value")
 
-            await manipulatePremiumPaidOf(policyholder3, BN.from(0))
-            expect(await solaceCoverProduct.premiumsPaidOf(policyholder3.address)).eq(0)
+            // await manipulatePremiumPaidOf(policyholder3, BN.from(0))
+            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder3.address)).eq(0)
         })
 
         it("can use referral code only once", async () => {
             // Temporary state change just for this state, set premiumPaidOf(policyholder3) = 100
-            await manipulatePremiumPaidOf(policyholder3, REFERRAL_THRESHOLD)
+            // await manipulatePremiumPaidOf(policyholder3, REFERRAL_THRESHOLD)
 
             let referralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
             
@@ -665,8 +665,8 @@ describe("SolaceCoverProduct", function() {
             await solaceCoverProduct.connect(coverPromotionAdmin).setRewardPoints(policyholder3.address, 0);
             expect(await solaceCoverProduct.rewardPointsOf(policyholder1.address)).eq(0)
             expect(await solaceCoverProduct.rewardPointsOf(policyholder3.address)).eq(0)
-            await manipulatePremiumPaidOf(policyholder3, BN.from(0))
-            expect(await solaceCoverProduct.premiumsPaidOf(policyholder3.address)).eq(0)
+            // await manipulatePremiumPaidOf(policyholder3, BN.from(0))
+            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder3.address)).eq(0)
         })
     });
 
@@ -816,43 +816,43 @@ describe("SolaceCoverProduct", function() {
             await solaceCoverProduct.connect(policyholder1).updateCoverLimit(initialCoverLimit, []);
             expect (await solaceCoverProduct.cooldownStart(policyholder1.address)).eq(0)
         })
-        it("cannot use a referral code, if premiumPaid < 100", async () => {
-            let referralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
-            let coverLimit = await solaceCoverProduct.coverLimitOf(POLICY_ID_2);
-            await expect(solaceCoverProduct.connect(policyholder2).updateCoverLimit(coverLimit, referralCode)).to.revertedWith("cannot apply referral code if premium paid < referralThreshold")
-        })
+        // it("cannot use a referral code, if premiumPaid < 100", async () => {
+        //     let referralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
+        //     let coverLimit = await solaceCoverProduct.coverLimitOf(POLICY_ID_2);
+        //     await expect(solaceCoverProduct.connect(policyholder2).updateCoverLimit(coverLimit, referralCode)).to.revertedWith("cannot apply referral code if premium paid < referralThreshold")
+        // })
         it("cannot use invalid referral code", async () => {
             // Temporary state change just for this state, set premiumPaidOf(policyholder1) = 100
-            await manipulatePremiumPaidOf(policyholder1, REFERRAL_THRESHOLD)
+            // await manipulatePremiumPaidOf(policyholder1, REFERRAL_THRESHOLD)
             
             let coverLimit = await solaceCoverProduct.coverLimitOf(POLICY_ID_1);
             await expect(solaceCoverProduct.connect(policyholder1).updateCoverLimit(coverLimit, FAKE_REFERRAL_CODE)).to.be.reverted;
 
-            await manipulatePremiumPaidOf(policyholder1, BN.from(0))
-            expect(await solaceCoverProduct.premiumsPaidOf(policyholder1.address)).eq(0)
+            // await manipulatePremiumPaidOf(policyholder1, BN.from(0))
+            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder1.address)).eq(0)
         })
         it("cannot use own referral code", async () => {
             // Temporary state change just for this state, set premiumPaidOf(policyholder1) = 100
-            await manipulatePremiumPaidOf(policyholder1, REFERRAL_THRESHOLD)
+            // await manipulatePremiumPaidOf(policyholder1, REFERRAL_THRESHOLD)
 
             let ownReferralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
             let coverLimit = await solaceCoverProduct.coverLimitOf(POLICY_ID_1);
             await expect(solaceCoverProduct.connect(policyholder1).updateCoverLimit(coverLimit, ownReferralCode)).to.revertedWith("cannot refer to self");
 
-            await manipulatePremiumPaidOf(policyholder1, BN.from(0))
-            expect(await solaceCoverProduct.premiumsPaidOf(policyholder1.address)).eq(0)
+            // await manipulatePremiumPaidOf(policyholder1, BN.from(0))
+            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder1.address)).eq(0)
         })
         it("cannot use referral code of an inactive policy holder", async () => {
             // Temporary state change just for this state, set premiumPaidOf(policyholder2) = 100
-            await manipulatePremiumPaidOf(policyholder2, REFERRAL_THRESHOLD)
+            // await manipulatePremiumPaidOf(policyholder2, REFERRAL_THRESHOLD)
 
             expect(await solaceCoverProduct.policyStatus(POLICY_ID_3)).eq(false)
             let referralCode = await getSolaceReferralCode(policyholder3, solaceCoverProduct)
             let coverLimit = await solaceCoverProduct.coverLimitOf(POLICY_ID_2);
             await expect(solaceCoverProduct.connect(policyholder2).updateCoverLimit(coverLimit, referralCode)).to.revertedWith("referrer must be active policy holder");
 
-            await manipulatePremiumPaidOf(policyholder2, BN.from(0))
-            expect(await solaceCoverProduct.premiumsPaidOf(policyholder2.address)).eq(0)
+            // await manipulatePremiumPaidOf(policyholder2, BN.from(0))
+            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder2.address)).eq(0)
         })
         it("will not give reward points if isReferralOn == false", async () => {
             // Set isReferralOn to false
@@ -876,7 +876,7 @@ describe("SolaceCoverProduct", function() {
         })
         it("can use referral code only once", async () => {
             // Temporary state change just for this state, set premiumPaidOf(policyholder2) = 100
-            await manipulatePremiumPaidOf(policyholder2, REFERRAL_THRESHOLD)
+            // await manipulatePremiumPaidOf(policyholder2, REFERRAL_THRESHOLD)
 
             let referralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
             let coverLimit = await solaceCoverProduct.coverLimitOf(POLICY_ID_2);
@@ -900,8 +900,8 @@ describe("SolaceCoverProduct", function() {
             await solaceCoverProduct.connect(coverPromotionAdmin).setRewardPoints(policyholder2.address, 0);
             expect(await solaceCoverProduct.rewardPointsOf(policyholder1.address)).eq(0)
             expect(await solaceCoverProduct.rewardPointsOf(policyholder2.address)).eq(0)
-            await manipulatePremiumPaidOf(policyholder2, BN.from(0))
-            expect(await solaceCoverProduct.premiumsPaidOf(policyholder2.address)).eq(0)
+            // await manipulatePremiumPaidOf(policyholder2, BN.from(0))
+            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder2.address)).eq(0)
         })
     });
 
@@ -1248,6 +1248,10 @@ describe("SolaceCoverProduct", function() {
             // Policy 1: reward points can pay for premium in full
             // Policy 2: reward points can partially pay for premium, rest will come from account balance
             // Policy 3: reward points + account balance unable to fully pay for premium
+
+            await manipulatePremiumPaidOf(policyholder1, REFERRAL_THRESHOLD)
+            await manipulatePremiumPaidOf(policyholder2, REFERRAL_THRESHOLD)
+            await manipulatePremiumPaidOf(policyholder3, REFERRAL_THRESHOLD)
 
             // Set up reward points for policy 1 and 2 - with setRewardPoints()
             let EXCESS_REWARD_POINTS = WEEKLY_MAX_PREMIUM.mul(2)

--- a/test/products/SolaceCoverProductFrax.test.ts
+++ b/test/products/SolaceCoverProductFrax.test.ts
@@ -5,7 +5,7 @@ import chai from "chai";
 import { config as dotenv_config } from "dotenv";
 import { import_artifacts, ArtifactImports } from "../utilities/artifact_importer";
 import { getSolaceReferralCode } from "../utilities/getSolaceReferralCode"
-import { Registry, RiskManager, SolaceCoverProduct, CoverageDataProvider, Solace, MockPriceOracle, MockSlp, MockErc20Permit } from "../../typechain";
+import { Registry, RiskManager, SolaceCoverProductFrax, CoverageDataProvider, Solace, MockPriceOracle, MockSlp, MockErc20Permit } from "../../typechain";
 import { Console } from "console";
 import { expectClose } from "./../utilities/math";
 
@@ -19,13 +19,13 @@ chai.use(solidity)
 const DOMAIN_NAME = "Solace.fi-SolaceCoverProduct";
 const VERSION = "1";
 
-describe("SolaceCoverProduct", function() {
+describe("SolaceCoverProductFrax", function() {
     let artifacts: ArtifactImports;
     let registry: Registry;
     let riskManager: RiskManager;
     let solace: Solace;
-    let solaceCoverProduct: SolaceCoverProduct;
-    let dai: MockErc20Permit;
+    let solaceCoverProduct: SolaceCoverProductFrax;
+    let frax: MockErc20Permit;
     let usdc: MockErc20Permit;
     let priceOracle: MockPriceOracle;
     let solaceUsdcPool: MockSlp;
@@ -34,10 +34,10 @@ describe("SolaceCoverProduct", function() {
     const [deployer, governor, newGovernor, policyholder1, policyholder2, policyholder3, policyholder4, policyholder5, underwritingPool, premiumPool, premiumCollector, coverPromotionAdmin, usdcPolicyholder] = provider.getWallets();
     const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
     const ONE_ETH = BN.from("1000000000000000000"); // 1 eth
-    const INITIAL_DEPOSIT = ONE_ETH.mul(1000); // 1000 DAI
-    const INITIAL_COVER_LIMIT = ONE_ETH.mul(10000); // 10000 DAI
-    const ONE_MILLION_DAI = ONE_ETH.mul(1000000)
-    const NEW_COVER_LIMIT = INITIAL_COVER_LIMIT.mul(2); // 20000 DAI
+    const INITIAL_DEPOSIT = ONE_ETH.mul(1000); // 1000 FRAX
+    const INITIAL_COVER_LIMIT = ONE_ETH.mul(10000); // 10000 FRAX
+    const ONE_MILLION_FRAX = ONE_ETH.mul(1000000)
+    const NEW_COVER_LIMIT = INITIAL_COVER_LIMIT.mul(2); // 20000 FRAX
     const ONE_TENTH_ETH = BN.from("100000000000000000"); // 0.1 eth
     const TWO_ETH = BN.from("2000000000000000000"); // 1 eth
     const ONE_THOUSAND_USDC = BN.from("1000000000")
@@ -45,9 +45,9 @@ describe("SolaceCoverProduct", function() {
     const ZERO_AMOUNT = BN.from("0");
     const ANNUAL_MAX_PREMIUM = INITIAL_COVER_LIMIT.div(10); // 0.1 eth, for testing we assume max annual rate of 10% of cover limit
     const WEEKLY_MAX_PREMIUM = ANNUAL_MAX_PREMIUM.mul(604800).div(31536000);
-    // mainnet
+    // polygon
     const TOKEN0 = "0x501ace9c35e60f03a2af4d484f49f9b1efde9f40"; // SOLACE.sol
-    const TOKEN1 = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"; // USDC.sol
+    const TOKEN1 = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"; // USDC.sol
     const RESERVE0 = BN.from("13250148273341498385651903");
     const RESERVE1 = BN.from("1277929641956");
     const STRATEGY_STATUS = {
@@ -63,16 +63,16 @@ describe("SolaceCoverProduct", function() {
     const ONE_WEEK = BN.from("604800");
     const maxRateNum = BN.from("1");
     const maxRateDenom = BN.from("315360000"); // We are testing with maxRateNum and maxRateDenom that gives us an annual max rate of 10% coverLimit
-    const REFERRAL_REWARD = ONE_ETH.mul(50) // 50 DAI
-    const REFERRAL_THRESHOLD = ONE_ETH.mul(100) // 100 DAI
+    const REFERRAL_REWARD = ONE_ETH.mul(50) // 50 FRAX
+    const REFERRAL_THRESHOLD = ONE_ETH.mul(100) // 100 FRAX
 
     // Random 130 character hex string
     const FAKE_REFERRAL_CODE = "0xe4e7cba021ff6b83b14d54016198f31b04cba044d71d9a8b9bdf964aa2259cc3b207237f814aa56e516638b448edc43a6c3f4637dca5de54cb199e37b039a832e7"
 
-    // mainnet
-    const DAI_ADDRESS = "0x6B175474E89094C44Da98b954EedeAC495271d0F"
-    const USDC_ADDRESS = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-    const WETH_ADDRESS = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    // polygon
+    const FRAX_ADDRESS = "0x45c32fA6DF82ead1e2EF74d17b76547EDdFaFF89"
+    const USDC_ADDRESS = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
+    const WETH_ADDRESS = "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619"
 
     before( async () => {
         artifacts = await import_artifacts();
@@ -88,37 +88,37 @@ describe("SolaceCoverProduct", function() {
 
         priceOracle = (await deployContract(deployer, artifacts.MockPriceOracle)) as MockPriceOracle;
         solaceUsdcPool = (await deployContract(deployer, artifacts.MockSLP, ["SushiSwap LP Token", "SLP", ONE_ETH.mul(1000000), TOKEN0, TOKEN1, RESERVE0, RESERVE1])) as MockSlp;
-        
+
         coverageDataProvider = (await deployContract(deployer, artifacts.CoverageDataProvider, [governor.address])) as CoverageDataProvider;
         await registry.connect(governor).set(["coverageDataProvider"], [coverageDataProvider.address])
     });
 
     describe("deployment", () => {
         let mockRegistry: Registry;
-        
+
         before(async () => {
             mockRegistry = (await deployContract(deployer, artifacts.Registry, [governor.address])) as Registry;
         });
 
         it("reverts for zero address registry", async () => {
-            await expect(deployContract(deployer, artifacts.SolaceCoverProduct, [governor.address, ZERO_ADDRESS, DOMAIN_NAME, VERSION])).to.be.revertedWith("zero address registry");
+            await expect(deployContract(deployer, artifacts.SolaceCoverProductFrax, [governor.address, ZERO_ADDRESS, DOMAIN_NAME, VERSION])).to.be.revertedWith("zero address registry");
         });
 
         it("reverts for zero address riskmanager", async () => {
-            await expect(deployContract(deployer, artifacts.SolaceCoverProduct, [governor.address, mockRegistry.address, DOMAIN_NAME, VERSION])).to.be.revertedWith("key not in mapping");
+            await expect(deployContract(deployer, artifacts.SolaceCoverProductFrax, [governor.address, mockRegistry.address, DOMAIN_NAME, VERSION])).to.be.revertedWith("key not in mapping");
         });
 
         it("reverts for zero address governance", async () => {
-            await expect(deployContract(deployer, artifacts.SolaceCoverProduct, [ZERO_ADDRESS, registry.address , DOMAIN_NAME, VERSION])).to.be.revertedWith("zero address governance");
+            await expect(deployContract(deployer, artifacts.SolaceCoverProductFrax, [ZERO_ADDRESS, registry.address , DOMAIN_NAME, VERSION])).to.be.revertedWith("zero address governance");
         });
 
-        it("reverts for zero address dai", async () => {
-            await expect(deployContract(deployer, artifacts.SolaceCoverProduct, [governor.address, registry.address , DOMAIN_NAME, VERSION])).to.be.revertedWith("key not in mapping");
-            await registry.connect(governor).set(["dai"], [DAI_ADDRESS])
+        it("reverts for zero address frax", async () => {
+            await expect(deployContract(deployer, artifacts.SolaceCoverProductFrax, [governor.address, registry.address , DOMAIN_NAME, VERSION])).to.be.revertedWith("key not in mapping");
+            await registry.connect(governor).set(["frax"], [FRAX_ADDRESS])
         });
 
         it("can deploy", async () => {
-            solaceCoverProduct = await deployContract(deployer, artifacts.SolaceCoverProduct, [governor.address, registry.address , DOMAIN_NAME, VERSION]) as SolaceCoverProduct;
+            solaceCoverProduct = await deployContract(deployer, artifacts.SolaceCoverProductFrax, [governor.address, registry.address , DOMAIN_NAME, VERSION]) as SolaceCoverProductFrax;
             expect(solaceCoverProduct.address).to.not.undefined;
         });
 
@@ -131,20 +131,20 @@ describe("SolaceCoverProduct", function() {
             expect(await solaceCoverProduct.isReferralOn()).eq(true);
         })
 
-        it("completes DAI setup", async() => {
-            const Dai = await ethers.getContractFactory("MockERC20Permit");
-            dai = await Dai.attach(DAI_ADDRESS) as MockErc20Permit
-            
-            // Give 10,000 DAI to all active test wallets
-            await manipulateDAIbalance(policyholder1, ONE_ETH.mul(10000))
-            await manipulateDAIbalance(governor, ONE_ETH.mul(10000))
-            expect(await dai.balanceOf(policyholder1.address)).eq(ONE_ETH.mul(10000))
-            expect(await dai.balanceOf(governor.address)).eq(ONE_ETH.mul(10000))
+        it("completes FRAX setup", async() => {
+            const Frax = await ethers.getContractFactory("MockERC20Permit");
+            frax = await Frax.attach(FRAX_ADDRESS) as MockErc20Permit
+
+            // Give 10,000 FRAX to all active test wallets
+            await manipulateFRAXbalance(policyholder1, ONE_ETH.mul(10000))
+            await manipulateFRAXbalance(governor, ONE_ETH.mul(10000))
+            expect(await frax.balanceOf(policyholder1.address)).eq(ONE_ETH.mul(10000))
+            expect(await frax.balanceOf(governor.address)).eq(ONE_ETH.mul(10000))
 
             // Grant infinite ERC20 allowance from active test wallets to Soteria
-            await dai.connect(policyholder1).approve(solaceCoverProduct.address, constants.MaxUint256)
-            await dai.connect(policyholder2).approve(solaceCoverProduct.address, constants.MaxUint256)
-            await dai.connect(governor).approve(solaceCoverProduct.address, constants.MaxUint256)
+            await frax.connect(policyholder1).approve(solaceCoverProduct.address, constants.MaxUint256)
+            await frax.connect(policyholder2).approve(solaceCoverProduct.address, constants.MaxUint256)
+            await frax.connect(governor).approve(solaceCoverProduct.address, constants.MaxUint256)
         })
         it("manipulatePremiumPaidOf helper function working", async() => {
             await manipulatePremiumPaidOf(deployer, BN.from(11))
@@ -187,23 +187,23 @@ describe("SolaceCoverProduct", function() {
         it("starts unpaused", async () => {
           expect(await solaceCoverProduct.paused()).to.equal(false);
         });
-    
+
         it("cannot be paused by non governance", async () => {
           await expect(solaceCoverProduct.connect(policyholder1).setPaused(true)).to.be.revertedWith("!governance");
           expect(await solaceCoverProduct.paused()).to.equal(false);
         });
-    
+
         it("can be paused", async () => {
           let tx = await solaceCoverProduct.connect(governor).setPaused(true);
           expect(tx).to.emit(solaceCoverProduct, "PauseSet").withArgs(true);
           expect(await solaceCoverProduct.paused()).to.equal(true);
         });
-    
+
         it("cannot be unpaused by non governance", async () => {
           await expect(solaceCoverProduct.connect(policyholder1).setPaused(false)).to.be.revertedWith("!governance");
           expect(await solaceCoverProduct.paused()).to.equal(true);
         });
-    
+
         it("can be unpaused", async () => {
           let tx = await solaceCoverProduct.connect(governor).setPaused(false);
           expect(tx).to.emit(solaceCoverProduct, "PauseSet").withArgs(false);
@@ -245,13 +245,13 @@ describe("SolaceCoverProduct", function() {
             await expect(solaceCoverProduct.connect(governor).setRegistry(registry2.address)).to.revertedWith("key not in mapping");
         });
 
-        it("reverts for zero address dai", async () => {
+        it("reverts for zero address frax", async () => {
             await registry2.connect(governor).set(["riskManager"], [riskManager2.address]);
             await expect(solaceCoverProduct.connect(governor).setRegistry(registry2.address)).to.revertedWith("key not in mapping");
         });
 
         it("governance can set registry", async () => {
-            await registry2.connect(governor).set(["dai"], [DAI_ADDRESS]);
+            await registry2.connect(governor).set(["frax"], [FRAX_ADDRESS]);
             let tx = await solaceCoverProduct.connect(governor).setRegistry(registry2.address);
             expect(tx).emit(solaceCoverProduct, "RegistrySet").withArgs(registry2.address);
             expect(await solaceCoverProduct.connect(policyholder1).riskManager()).to.equal(riskManager2.address);
@@ -455,7 +455,7 @@ describe("SolaceCoverProduct", function() {
 
         before(async () => {
             await riskManager.connect(governor).addCoverLimitUpdater(solaceCoverProduct.address);
-            
+
             // risk manager active cover amount and active cover amount for soteria.
             rmActiveCoverLimit = await riskManager.activeCoverLimit();
             rmSoteriaactiveCoverLimit = await riskManager.activeCoverLimitPerStrategy(solaceCoverProduct.address);
@@ -490,11 +490,11 @@ describe("SolaceCoverProduct", function() {
             expect(maxCover1).to.equal(0)
             expect(await coverageDataProvider.numOfPools()).to.equal(0);
 
-            await coverageDataProvider.connect(governor).set("underwritingPool", ONE_MILLION_DAI);
+            await coverageDataProvider.connect(governor).set("underwritingPool", ONE_MILLION_FRAX);
             expect(await coverageDataProvider.connect(governor).numOfPools()).to.equal(1);
             let maxCover2 = await riskManager.maxCover();
-            expect(maxCover2).to.equal(maxCover1.add(ONE_MILLION_DAI));
-            
+            expect(maxCover2).to.equal(maxCover1.add(ONE_MILLION_FRAX));
+
             // add Soteria to the risk manager and assign coverage allocation
             await riskManager.connect(governor).addRiskStrategy(solaceCoverProduct.address);
             await riskManager.connect(governor).setStrategyStatus(solaceCoverProduct.address, STRATEGY_STATUS.ACTIVE);
@@ -509,7 +509,7 @@ describe("SolaceCoverProduct", function() {
         });
 
         it("cannot buy policy when insufficient user balance for deposit", async () => {
-            const userBalance = await dai.balanceOf(policyholder1.address)
+            const userBalance = await frax.balanceOf(policyholder1.address)
             await expect(solaceCoverProduct.connect(policyholder1).activatePolicy(policyholder1.address, ONE_ETH, userBalance.mul(2), [])).to.revertedWith("insufficient caller balance for deposit");
         })
 
@@ -517,7 +517,7 @@ describe("SolaceCoverProduct", function() {
             await expect(solaceCoverProduct.connect(policyholder1).activatePolicy(policyholder1.address, ONE_ETH, 0, [])).to.revertedWith("insufficient deposit for minimum required account balance");
         });
 
-        it("can activate policy - 10000 DAI cover with 1000 DAI deposit", async () => {
+        it("can activate policy - 10000 FRAX cover with 1000 FRAX deposit", async () => {
             let tx = await solaceCoverProduct.connect(policyholder1).activatePolicy(policyholder1.address, INITIAL_COVER_LIMIT, INITIAL_DEPOSIT, []);
 
             await expect(tx).emit(solaceCoverProduct, "PolicyCreated").withArgs(POLICY_ID_1);
@@ -533,7 +533,7 @@ describe("SolaceCoverProduct", function() {
             expect (await riskManager.activeCoverLimitPerStrategy(solaceCoverProduct.address)).eq(INITIAL_COVER_LIMIT)
             expect (await solaceCoverProduct.policyCount()).eq(1)
             expect (await solaceCoverProduct.coverLimitOf(POLICY_ID_1)).eq(INITIAL_COVER_LIMIT)
-            expect(await dai.balanceOf(solaceCoverProduct.address)).to.equal(INITIAL_DEPOSIT);
+            expect(await frax.balanceOf(solaceCoverProduct.address)).to.equal(INITIAL_DEPOSIT);
             expect (await solaceCoverProduct.cooldownStart(policyholder1.address)).eq(0)
         });
 
@@ -541,14 +541,14 @@ describe("SolaceCoverProduct", function() {
             await expect(solaceCoverProduct.connect(policyholder1).activatePolicy(policyholder1.address, INITIAL_COVER_LIMIT, INITIAL_DEPOSIT, [])).to.be.revertedWith("policy already activated")
             await expect(solaceCoverProduct.connect(policyholder2).activatePolicy(policyholder1.address, INITIAL_COVER_LIMIT, INITIAL_DEPOSIT, [])).to.be.revertedWith("policy already activated")
         })
-        
+
         it("cannot transfer policy", async () => {
             await expect(solaceCoverProduct.connect(policyholder1).transferFrom(policyholder1.address, policyholder2.address, 1)).to.be.revertedWith("only minting permitted");
             await expect(solaceCoverProduct.connect(policyholder1).transferFrom(policyholder1.address, ZERO_ADDRESS, 1)).to.be.revertedWith("ERC721: transfer to the zero address");
             // TO-DO, test ERC721.safeTransferFrom() => TypeError: solaceCoverProduct.connect(...).safeTransferFrom is not a function
         })
 
-        it("can activate policy for another address - 10000 DAI cover with 1000 DAI deposit", async () => {
+        it("can activate policy for another address - 10000 FRAX cover with 1000 FRAX deposit", async () => {
             let tx = await solaceCoverProduct.connect(policyholder1).activatePolicy(policyholder2.address, INITIAL_COVER_LIMIT, INITIAL_DEPOSIT, []);
 
             await expect(tx).emit(solaceCoverProduct, "PolicyCreated").withArgs(POLICY_ID_2);
@@ -565,7 +565,7 @@ describe("SolaceCoverProduct", function() {
             expect (await riskManager.activeCoverLimitPerStrategy(solaceCoverProduct.address)).eq(INITIAL_COVER_LIMIT.mul(2))
             expect (await solaceCoverProduct.policyCount()).eq(2)
             expect (await solaceCoverProduct.coverLimitOf(POLICY_ID_2)).eq(INITIAL_COVER_LIMIT)
-            expect(await dai.balanceOf(solaceCoverProduct.address)).to.equal(INITIAL_DEPOSIT.mul(2));
+            expect(await frax.balanceOf(solaceCoverProduct.address)).to.equal(INITIAL_DEPOSIT.mul(2));
             expect (await solaceCoverProduct.cooldownStart(policyholder2.address)).eq(0)
         });
         it("policy holder should have policy nft after buying coverage", async () => {
@@ -597,7 +597,7 @@ describe("SolaceCoverProduct", function() {
             expect(await solaceCoverProduct.isReferralOn()).eq(false)
 
             // Get valid referral code (we know it is valid, because it works in the next unit test)
-            
+
             let referralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
             let coverLimit = await solaceCoverProduct.coverLimitOf(POLICY_ID_2);
 
@@ -624,7 +624,7 @@ describe("SolaceCoverProduct", function() {
         it("cannot use own referral code", async () => {
             // Temporary state change just for this state, set premiumPaidOf(policyholder3) = 100
             await manipulatePremiumPaidOf(policyholder3, REFERRAL_THRESHOLD)
-            
+
             // Create new wallet just for this unit test scope, to avoid creating side effects that impact other unit tests. It's a headfuck to work that out.
             const ownReferralCode = await getSolaceReferralCode(policyholder3, solaceCoverProduct)
             await expect(solaceCoverProduct.connect(governor).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, INITIAL_DEPOSIT, ownReferralCode)).to.revertedWith("cannot refer to self");
@@ -647,7 +647,7 @@ describe("SolaceCoverProduct", function() {
             await manipulatePremiumPaidOf(policyholder3, REFERRAL_THRESHOLD)
 
             let referralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
-            
+
             let tx = await solaceCoverProduct.connect(governor).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, INITIAL_DEPOSIT, referralCode);
             await expect(tx).emit(solaceCoverProduct, "PolicyCreated").withArgs(POLICY_ID_3);
             await expect(tx).emit(solaceCoverProduct, "ReferralRewardsEarned").withArgs(policyholder1.address, REFERRAL_REWARD);
@@ -685,22 +685,22 @@ describe("SolaceCoverProduct", function() {
         })
         it("can deposit", async () => {
             let accountBalance = await solaceCoverProduct.accountBalanceOf(policyholder1.address);
-            let soteriaContractDAIbalance = await dai.balanceOf(solaceCoverProduct.address)
+            let soteriaContractFRAXbalance = await frax.balanceOf(solaceCoverProduct.address)
             let tx = await solaceCoverProduct.connect(policyholder1).deposit(policyholder1.address, INITIAL_DEPOSIT);
             await expect(tx).emit(solaceCoverProduct, "DepositMade").withArgs(policyholder1.address, policyholder1.address, INITIAL_DEPOSIT);
             expect(await solaceCoverProduct.accountBalanceOf(policyholder1.address)).to.equal(accountBalance.add(INITIAL_DEPOSIT));
-            expect(await dai.balanceOf(solaceCoverProduct.address)).to.equal(soteriaContractDAIbalance.add(INITIAL_DEPOSIT));
+            expect(await frax.balanceOf(solaceCoverProduct.address)).to.equal(soteriaContractFRAXbalance.add(INITIAL_DEPOSIT));
         });
 
         it("can deposit on behalf of policy holder", async () => {
             let accountBalance = await solaceCoverProduct.accountBalanceOf(policyholder2.address);
-            let soteriaContractDAIbalance = await dai.balanceOf(solaceCoverProduct.address)
+            let soteriaContractFRAXbalance = await frax.balanceOf(solaceCoverProduct.address)
             let tx = await solaceCoverProduct.connect(policyholder1).deposit(policyholder2.address, INITIAL_DEPOSIT);
             await expect(tx).emit(solaceCoverProduct, "DepositMade").withArgs(policyholder1.address, policyholder2.address, INITIAL_DEPOSIT);
             expect(await solaceCoverProduct.accountBalanceOf(policyholder2.address)).to.equal(accountBalance.add(INITIAL_DEPOSIT));
-            expect(await dai.balanceOf(solaceCoverProduct.address)).to.equal(soteriaContractDAIbalance.add(INITIAL_DEPOSIT));
+            expect(await frax.balanceOf(solaceCoverProduct.address)).to.equal(soteriaContractFRAXbalance.add(INITIAL_DEPOSIT));
         });
-        
+
         it("cannot deposit while paused", async () => {
             await solaceCoverProduct.connect(governor).setPaused(true);
             await expect(solaceCoverProduct.connect(policyholder1).deposit(policyholder1.address, INITIAL_DEPOSIT)).to.revertedWith("contract paused");
@@ -726,7 +726,7 @@ describe("SolaceCoverProduct", function() {
             // risk manager current values
             initialMCR = await riskManager.minCapitalRequirement();
             initialMCRForSoteria = await riskManager.minCapitalRequirementPerStrategy(solaceCoverProduct.address);
-            
+
             // risk manager current values
             initialRMActiveCoverLimit = await riskManager.activeCoverLimit();
             initialRMActiveCoverLimitForSoteria = await riskManager.activeCoverLimitPerStrategy(solaceCoverProduct.address);
@@ -765,16 +765,16 @@ describe("SolaceCoverProduct", function() {
             let chargeCycle = await solaceCoverProduct.chargeCycle();
             let accountBalance = await solaceCoverProduct.accountBalanceOf(policyholder1.address)
             let maxPermissibleNewCoverLimit = accountBalance.mul(maxRateDenom).div(maxRateNum).div(chargeCycle)
-            
+
             // Temporarily increase underwriting pool balance to avoid running into "insufficient capacity for new cover" revert
-            await coverageDataProvider.connect(governor).set("underwritingPool", ONE_MILLION_DAI.mul(1000000));
+            await coverageDataProvider.connect(governor).set("underwritingPool", ONE_MILLION_FRAX.mul(1000000));
             await expect(solaceCoverProduct.connect(policyholder1).updateCoverLimit(maxPermissibleNewCoverLimit.add(ONE_ETH), [])).to.revertedWith("insufficient deposit for minimum required account balance");
-            await coverageDataProvider.connect(governor).set("underwritingPool", ONE_MILLION_DAI);
+            await coverageDataProvider.connect(governor).set("underwritingPool", ONE_MILLION_FRAX);
         })
 
         it("policy owner can update policy", async () => {
             let activeCoverLimit = initialSoteriaActiveCoverLimit.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
-            
+
             let tx = await solaceCoverProduct.connect(policyholder1).updateCoverLimit(NEW_COVER_LIMIT, []);
 
             await expect(tx).emit(solaceCoverProduct, "PolicyUpdated").withArgs(POLICY_ID_1);
@@ -800,7 +800,7 @@ describe("SolaceCoverProduct", function() {
             expect(await riskManager.activeCoverLimitPerStrategy(solaceCoverProduct.address)).to.equal(amount2);
         });
 
-        it("should update risk manager mcr", async () => {         
+        it("should update risk manager mcr", async () => {
             let amount1 = initialMCR.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
             let amount2 = initialMCRForSoteria.add(NEW_COVER_LIMIT).sub(initialPolicyCoverLimit);
             expect(await riskManager.minCapitalRequirement()).to.equal(amount1);
@@ -824,7 +824,7 @@ describe("SolaceCoverProduct", function() {
         it("cannot use invalid referral code", async () => {
             // Temporary state change just for this state, set premiumPaidOf(policyholder1) = 100
             await manipulatePremiumPaidOf(policyholder1, REFERRAL_THRESHOLD)
-            
+
             let coverLimit = await solaceCoverProduct.coverLimitOf(POLICY_ID_1);
             await expect(solaceCoverProduct.connect(policyholder1).updateCoverLimit(coverLimit, FAKE_REFERRAL_CODE)).to.be.reverted;
 
@@ -927,7 +927,7 @@ describe("SolaceCoverProduct", function() {
             let tx = await solaceCoverProduct.connect(policyholder3).deactivatePolicy();
             await expect(tx).emit(solaceCoverProduct, "PolicyDeactivated").withArgs(POLICY_ID_3);
             await expect(tx).emit(riskManager, "ActiveCoverLimitUpdated").withArgs(solaceCoverProduct.address, initialRMActiveCoverLimit, initialRMActiveCoverLimit.sub(initialPolicyCoverLimit));
-            
+
             // user balance should not change
             let receipt = await tx.wait();
             let gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice);
@@ -955,10 +955,10 @@ describe("SolaceCoverProduct", function() {
 
     describe("withdraw", () => {
         let initialAccountBalance: BN;
-        let initialAccountDAIBalance: BN;
+        let initialAccountFRAXBalance: BN;
         let initialPolicyCover:BN;
-        let initialPolicyholderDAIBalance: BN;
-        let initialSoteriaDAIBalance: BN;
+        let initialPolicyholderFRAXBalance: BN;
+        let initialSoteriaFRAXBalance: BN;
         let initialActiveCoverLimit: BN;
         let initialAvailableCoverCapacity: BN;
         let initialRMActiveCoverLimit: BN;
@@ -976,8 +976,8 @@ describe("SolaceCoverProduct", function() {
             initialAccountBalance = await solaceCoverProduct.accountBalanceOf(policyholder3.address);
             initialPolicyCover = await solaceCoverProduct.coverLimitOf(POLICY_ID_3);
 
-            initialPolicyholderDAIBalance = await dai.balanceOf(policyholder3.address)
-            initialSoteriaDAIBalance = await dai.balanceOf(solaceCoverProduct.address)
+            initialPolicyholderFRAXBalance = await frax.balanceOf(policyholder3.address)
+            initialSoteriaFRAXBalance = await frax.balanceOf(solaceCoverProduct.address)
 
             initialActiveCoverLimit = await solaceCoverProduct.connect(policyholder3).activeCoverLimit();
             initialAvailableCoverCapacity = await solaceCoverProduct.availableCoverCapacity();
@@ -991,7 +991,7 @@ describe("SolaceCoverProduct", function() {
             cooldownStart =  await solaceCoverProduct.cooldownStart(policyholder3.address)
             cooldownPeriod = await solaceCoverProduct.cooldownPeriod()
         })
-        
+
         it("minRequiredAccountBalance view function working", async () => {
             expect(await solaceCoverProduct.minRequiredAccountBalance(INITIAL_COVER_LIMIT)).eq(minRequiredAccountBalance)
         })
@@ -1008,7 +1008,7 @@ describe("SolaceCoverProduct", function() {
         })
 
         it("when cooldown not started, will withdraw such that remaining balance = minRequiredAccountBalance", async () => {
-            const initialPolicyholder2DAIBalance = await dai.balanceOf(policyholder2.address)
+            const initialPolicyholder2FRAXBalance = await frax.balanceOf(policyholder2.address)
             const initialAccountBalanceOfPolicyHolder2 = await solaceCoverProduct.accountBalanceOf(policyholder2.address)
             expect(await solaceCoverProduct.cooldownStart(policyholder2.address)).eq(0)
 
@@ -1018,11 +1018,11 @@ describe("SolaceCoverProduct", function() {
 
             expect(initialAccountBalanceOfPolicyHolder2).gt(await solaceCoverProduct.accountBalanceOf(policyholder2.address))
             expect(await solaceCoverProduct.accountBalanceOf(policyholder2.address)).eq(minRequiredAccountBalance)
-            expect(await dai.balanceOf(policyholder2.address)).eq(initialPolicyholder2DAIBalance.add(withdrawAmount))
-            expect(await dai.balanceOf(solaceCoverProduct.address)).eq(initialSoteriaDAIBalance.sub(withdrawAmount))
+            expect(await frax.balanceOf(policyholder2.address)).eq(initialPolicyholder2FRAXBalance.add(withdrawAmount))
+            expect(await frax.balanceOf(solaceCoverProduct.address)).eq(initialSoteriaFRAXBalance.sub(withdrawAmount))
 
             await solaceCoverProduct.connect(policyholder2).deposit(policyholder2.address, withdrawAmount);
-            expect(await dai.balanceOf(policyholder2.address)).eq(initialPolicyholder2DAIBalance)
+            expect(await frax.balanceOf(policyholder2.address)).eq(initialPolicyholder2FRAXBalance)
             expect(await solaceCoverProduct.accountBalanceOf(policyholder2.address)).eq(initialAccountBalanceOfPolicyHolder2)
         })
         it("before cooldown complete, will withdraw such that remaining balance = minRequiredAccountBalance", async () => {
@@ -1030,7 +1030,7 @@ describe("SolaceCoverProduct", function() {
             const currentTimestamp = (await provider.getBlock('latest')).timestamp
             expect(cooldownStart).gt(0)
             expect(currentTimestamp).lt(cooldownStart.add(cooldownPeriod))
-            
+
             withdrawAmount = initialAccountBalance.sub(minRequiredAccountBalance)
 
             let tx = await solaceCoverProduct.connect(policyholder3).withdraw();
@@ -1038,24 +1038,24 @@ describe("SolaceCoverProduct", function() {
 
             expect(initialAccountBalance).gt(await solaceCoverProduct.accountBalanceOf(policyholder3.address))
             expect(await solaceCoverProduct.accountBalanceOf(policyholder3.address)).eq(minRequiredAccountBalance)
-            expect(await dai.balanceOf(policyholder3.address)).eq(initialPolicyholderDAIBalance.add(withdrawAmount))
-            expect(await dai.balanceOf(solaceCoverProduct.address)).eq(initialSoteriaDAIBalance.sub(withdrawAmount))
+            expect(await frax.balanceOf(policyholder3.address)).eq(initialPolicyholderFRAXBalance.add(withdrawAmount))
+            expect(await frax.balanceOf(solaceCoverProduct.address)).eq(initialSoteriaFRAXBalance.sub(withdrawAmount))
         })
         it("after cooldown complete, can withdraw entire account balance", async () => {
             const initialTimestamp = (await provider.getBlock('latest')).timestamp
             const postCooldownTimestamp = initialTimestamp + cooldownPeriod.toNumber()
             expect(BN.from(postCooldownTimestamp)).gt(cooldownStart.add(cooldownPeriod))
             await provider.send("evm_mine", [postCooldownTimestamp])
-            
-            let policyholderDAIBalance = await dai.balanceOf(policyholder3.address)
-            let soteriaDAIBalance = await dai.balanceOf(solaceCoverProduct.address)
+
+            let policyholderFRAXBalance = await frax.balanceOf(policyholder3.address)
+            let soteriaFRAXBalance = await frax.balanceOf(solaceCoverProduct.address)
             let accountBalance = await solaceCoverProduct.accountBalanceOf(policyholder3.address)
             let tx = await solaceCoverProduct.connect(policyholder3).withdraw();
             await expect(tx).emit(solaceCoverProduct, "WithdrawMade").withArgs(policyholder3.address, accountBalance);
 
             expect(await solaceCoverProduct.accountBalanceOf(policyholder3.address)).eq(0);
-            expect(await dai.balanceOf(policyholder3.address)).eq(policyholderDAIBalance.add(accountBalance))
-            expect(await dai.balanceOf(solaceCoverProduct.address)).eq(soteriaDAIBalance.sub(accountBalance))
+            expect(await frax.balanceOf(policyholder3.address)).eq(policyholderFRAXBalance.add(accountBalance))
+            expect(await frax.balanceOf(solaceCoverProduct.address)).eq(soteriaFRAXBalance.sub(accountBalance))
         })
 
         after(async () => {
@@ -1081,11 +1081,11 @@ describe("SolaceCoverProduct", function() {
 
         it("can charge premiums", async () => {
             // CASE 1 - Charge weekly premium for two policyholders, no reward points involved
-            
+
             let policyholder1AccountBalance = await solaceCoverProduct.connect(policyholder1).accountBalanceOf(policyholder1.address);
             let policyholder2AccountBalance = await solaceCoverProduct.connect(policyholder1).accountBalanceOf(policyholder2.address);
-            let initialContractDAIBalance = await dai.balanceOf(solaceCoverProduct.address)
-            let initialPremiumPoolDAIBalance = await dai.balanceOf(premiumPool.address)
+            let initialContractFRAXBalance = await frax.balanceOf(solaceCoverProduct.address)
+            let initialPremiumPoolFRAXBalance = await frax.balanceOf(premiumPool.address)
             let initialCoverLimit1 = await solaceCoverProduct.coverLimitOf(POLICY_ID_1);
             let initialCoverLimit2 = await solaceCoverProduct.coverLimitOf(POLICY_ID_2);
             let initialActiveCoverLimit = await solaceCoverProduct.activeCoverLimit();
@@ -1100,8 +1100,8 @@ describe("SolaceCoverProduct", function() {
             expect(await solaceCoverProduct.premiumsPaidOf(policyholder2.address)).eq(WEEKLY_MAX_PREMIUM)
 
             // premiums should be transferred to premium pool
-            expect(await dai.balanceOf(solaceCoverProduct.address)).eq(initialContractDAIBalance.sub(WEEKLY_MAX_PREMIUM.mul(2)))
-            expect(await dai.balanceOf(premiumPool.address)).eq(initialPremiumPoolDAIBalance.add(WEEKLY_MAX_PREMIUM.mul(2)))
+            expect(await frax.balanceOf(solaceCoverProduct.address)).eq(initialContractFRAXBalance.sub(WEEKLY_MAX_PREMIUM.mul(2)))
+            expect(await frax.balanceOf(premiumPool.address)).eq(initialPremiumPoolFRAXBalance.add(WEEKLY_MAX_PREMIUM.mul(2)))
 
             // Soteria account balance should be decreased
             expect(await solaceCoverProduct.accountBalanceOf(policyholder1.address)).to.equal(policyholder1AccountBalance.sub(WEEKLY_MAX_PREMIUM));
@@ -1118,8 +1118,8 @@ describe("SolaceCoverProduct", function() {
             // CASE 2 - Charge more than minRequiredAccountBalance to a policyholder
             let policyholder1AccountBalance = await solaceCoverProduct.connect(policyholder1).accountBalanceOf(policyholder1.address);
             let initialCoverLimit1 = await solaceCoverProduct.coverLimitOf(POLICY_ID_1);
-            let initialContractDAIBalance = await dai.balanceOf(solaceCoverProduct.address)
-            let initialPremiumPoolDAIBalance = await dai.balanceOf(premiumPool.address)
+            let initialContractFRAXBalance = await frax.balanceOf(solaceCoverProduct.address)
+            let initialPremiumPoolFRAXBalance = await frax.balanceOf(premiumPool.address)
             let minRequiredAccountBalance = maxRateNum.mul(ONE_WEEK).mul(initialCoverLimit1).div(maxRateDenom);
             let initialPremiumPaid1 = await solaceCoverProduct.premiumsPaidOf(policyholder1.address);
 
@@ -1129,8 +1129,8 @@ describe("SolaceCoverProduct", function() {
 
             expect(await solaceCoverProduct.premiumsPaidOf(policyholder1.address)).eq(initialPremiumPaid1.add(minRequiredAccountBalance))
             expect(await solaceCoverProduct.accountBalanceOf(policyholder1.address)).to.equal(policyholder1AccountBalance.sub(minRequiredAccountBalance));
-            expect(await dai.balanceOf(solaceCoverProduct.address)).eq(initialContractDAIBalance.sub(minRequiredAccountBalance))
-            expect(await dai.balanceOf(premiumPool.address)).eq(initialPremiumPoolDAIBalance.add(minRequiredAccountBalance))
+            expect(await frax.balanceOf(solaceCoverProduct.address)).eq(initialContractFRAXBalance.sub(minRequiredAccountBalance))
+            expect(await frax.balanceOf(premiumPool.address)).eq(initialPremiumPoolFRAXBalance.add(minRequiredAccountBalance))
         })
 
         it("can partially charge premiums if the fund is insufficient", async () => {
@@ -1148,8 +1148,8 @@ describe("SolaceCoverProduct", function() {
             let initialAvailableCoverCapacity = await solaceCoverProduct.connect(policyholder4).availableCoverCapacity();
             let initialRMCoverAmount = await riskManager.activeCoverLimit();
             let initialRMSoteriaCoverAmount = await riskManager.activeCoverLimitPerStrategy(solaceCoverProduct.address);
-            let initialContractDAIBalance = await dai.balanceOf(solaceCoverProduct.address)
-            let initialPremiumPoolDAIBalance = await dai.balanceOf(premiumPool.address)
+            let initialContractFRAXBalance = await frax.balanceOf(solaceCoverProduct.address)
+            let initialPremiumPoolFRAXBalance = await frax.balanceOf(premiumPool.address)
             let initialPremiumPaid4 = await solaceCoverProduct.premiumsPaidOf(policyholder4.address);
 
             // we cannot reach the PremiumPartiallyCharged branch within a single chargePremiums() call
@@ -1157,7 +1157,7 @@ describe("SolaceCoverProduct", function() {
             expect(await solaceCoverProduct.accountBalanceOf(policyholder4.address)).eq(WEEKLY_MAX_PREMIUM.div(10))
             tx = await solaceCoverProduct.connect(premiumCollector).chargePremiums([policyholder4.address], [WEEKLY_MAX_PREMIUM]);
             await expect(tx).emit(solaceCoverProduct, "PremiumPartiallyCharged").withArgs(policyholder4.address, WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM.div(10));
-           
+
             // policy should be deactivated
             await expect(tx).emit(solaceCoverProduct, "PolicyDeactivated").withArgs(POLICY_ID_4);
             await expect(tx).emit(riskManager, "ActiveCoverLimitUpdated").withArgs(solaceCoverProduct.address, initialActiveCoverLimit, initialActiveCoverLimit.sub(initialPolicyCoverLimit));
@@ -1179,14 +1179,14 @@ describe("SolaceCoverProduct", function() {
             expect(await solaceCoverProduct.accountBalanceOf(policyholder4.address)).to.equal(0);
             expect(await solaceCoverProduct.premiumsPaidOf(policyholder4.address)).eq(initialPremiumPaid4.add(depositAmount))
 
-            // dai should be transferred to premium pool
-            expect(await dai.balanceOf(solaceCoverProduct.address)).eq(initialContractDAIBalance.sub(depositAmount))
-            expect(await dai.balanceOf(premiumPool.address)).eq(initialPremiumPoolDAIBalance.add(depositAmount))
+            // frax should be transferred to premium pool
+            expect(await frax.balanceOf(solaceCoverProduct.address)).eq(initialContractFRAXBalance.sub(depositAmount))
+            expect(await frax.balanceOf(premiumPool.address)).eq(initialPremiumPoolFRAXBalance.add(depositAmount))
         });
 
         it("will be able to charge premiums for accounts that have been deactivated in the last epoch", async () => {
             // CASE 4 - Create a new account, deactivate it, then charge premium on this newly deactivated account
-            
+
             // Create a new account, then deactivate it
             await solaceCoverProduct.connect(governor).activatePolicy(policyholder5.address, INITIAL_COVER_LIMIT, INITIAL_DEPOSIT, [])
             expect(await solaceCoverProduct.policyStatus(POLICY_ID_5)).to.equal(true);
@@ -1195,18 +1195,18 @@ describe("SolaceCoverProduct", function() {
 
             // Get initial balances
             let initialHolderFunds = await solaceCoverProduct.accountBalanceOf(policyholder5.address);
-            let initialContractDAIBalance = await dai.balanceOf(solaceCoverProduct.address)
-            let initialPremiumPoolDAIBalance = await dai.balanceOf(premiumPool.address)
+            let initialContractFRAXBalance = await frax.balanceOf(solaceCoverProduct.address)
+            let initialPremiumPoolFRAXBalance = await frax.balanceOf(premiumPool.address)
             let initialPremiumPaid5 = await solaceCoverProduct.premiumsPaidOf(policyholder5.address);
 
             // Charge premiums
             let tx = await solaceCoverProduct.connect(premiumCollector).chargePremiums([policyholder5.address], [WEEKLY_MAX_PREMIUM]);
             await expect(tx).emit(solaceCoverProduct, "PremiumCharged").withArgs(policyholder5.address, WEEKLY_MAX_PREMIUM);
-         
+
             // Check balances
             expect(await solaceCoverProduct.accountBalanceOf(policyholder5.address)).to.equal(initialHolderFunds.sub(WEEKLY_MAX_PREMIUM));
-            expect(await dai.balanceOf(solaceCoverProduct.address)).eq(initialContractDAIBalance.sub(WEEKLY_MAX_PREMIUM))
-            expect(await dai.balanceOf(premiumPool.address)).eq(initialPremiumPoolDAIBalance.add(WEEKLY_MAX_PREMIUM))
+            expect(await frax.balanceOf(solaceCoverProduct.address)).eq(initialContractFRAXBalance.sub(WEEKLY_MAX_PREMIUM))
+            expect(await frax.balanceOf(premiumPool.address)).eq(initialPremiumPoolFRAXBalance.add(WEEKLY_MAX_PREMIUM))
             expect(await solaceCoverProduct.premiumsPaidOf(policyholder5.address)).eq(initialPremiumPaid5.add(WEEKLY_MAX_PREMIUM))
         })
 
@@ -1214,13 +1214,13 @@ describe("SolaceCoverProduct", function() {
             // CASE 4 (REUNDANT FOR NOW) - Policy holder 5 withdraws, then premium is charged twice
             // Redundant because we allow the edge case of premium collector charging a deactivated account more than once
 
-            // let initialSoteriaBalance = await dai.balanceOf(solaceCoverProduct.address);
-            // let initialPremiumPoolBalance = await dai.balanceOf(premiumPool.address);
+            // let initialSoteriaBalance = await frax.balanceOf(solaceCoverProduct.address);
+            // let initialPremiumPoolBalance = await frax.balanceOf(premiumPool.address);
             // let initialHolderFunds = await solaceCoverProduct.accountBalanceOf(policyholder5.address);
 
             // // Policy holder 5 withdraw
             // await solaceCoverProduct.connect(policyholder5).withdraw();
-            
+
             // let minRequiredAccountBalance = maxRateNum.mul(ONE_WEEK).mul(INITIAL_COVER_LIMIT).div(maxRateDenom)
             // console.log(Number(minRequiredAccountBalance))
             // console.log(Number(await solaceCoverProduct.accountBalanceOf(policyholder5.address)))
@@ -1233,14 +1233,14 @@ describe("SolaceCoverProduct", function() {
 
             // let tx = solaceCoverProduct.connect(premiumCollector).chargePremiums([policyholder2.address, policyholder4.address], [WEEKLY_MAX_PREMIUM, WEEKLY_MAX_PREMIUM]);
             // await expect(tx).emit(solaceCoverProduct, "PremiumCharged").withArgs(policyholder2.address, WEEKLY_MAX_PREMIUM);
-         
+
             // expect(await solaceCoverProduct.connect(policyholder2).accountBalanceOf(policyholder2.address)).to.equal(initialHolderFunds.sub(WEEKLY_MAX_PREMIUM));
-         
+
             // // soteria balance should be decreased by single weekly premium
-            // expect(await dai.balanceOf(solaceCoverProduct.address)).to.equal(initialSoteriaBalance.sub(WEEKLY_MAX_PREMIUM));
-          
+            // expect(await frax.balanceOf(solaceCoverProduct.address)).to.equal(initialSoteriaBalance.sub(WEEKLY_MAX_PREMIUM));
+
             // // single weekly premium should be sent to premium pool
-            // expect(await dai.balanceOf(premiumPool.address)).to.equal(initialPremiumPoolBalance.add(WEEKLY_MAX_PREMIUM));
+            // expect(await frax.balanceOf(premiumPool.address)).to.equal(initialPremiumPoolBalance.add(WEEKLY_MAX_PREMIUM));
         // });
 
         it("will correctly charge premiums with reward points", async () => {
@@ -1285,8 +1285,8 @@ describe("SolaceCoverProduct", function() {
             let initialAvailableCoverCapacity = await solaceCoverProduct.availableCoverCapacity();
             let initialRMCoverAmount = await riskManager.activeCoverLimit();
             let initialRMSoteriaCoverAmount = await riskManager.activeCoverLimitPerStrategy(solaceCoverProduct.address);
-            let initialContractDAIBalance = await dai.balanceOf(solaceCoverProduct.address)
-            let initialPremiumPoolDAIBalance = await dai.balanceOf(premiumPool.address)
+            let initialContractFRAXBalance = await frax.balanceOf(solaceCoverProduct.address)
+            let initialPremiumPoolFRAXBalance = await frax.balanceOf(premiumPool.address)
             let initialPremiumPaid1 = await solaceCoverProduct.premiumsPaidOf(policyholder1.address);
             let initialPremiumPaid2 = await solaceCoverProduct.premiumsPaidOf(policyholder2.address);
             let initialPremiumPaid3 = await solaceCoverProduct.premiumsPaidOf(policyholder3.address);
@@ -1297,7 +1297,7 @@ describe("SolaceCoverProduct", function() {
             expect(tx).to.emit(solaceCoverProduct, "PremiumPartiallyCharged").withArgs(policyholder3.address, WEEKLY_MAX_PREMIUM, initialHolder3AccountBalance.add(initialRewardPoints3));
             expect(tx).to.emit(solaceCoverProduct, "PolicyDeactivated").withArgs(POLICY_ID_3);
             await expect(tx).emit(riskManager, "ActiveCoverLimitUpdated").withArgs(solaceCoverProduct.address, initialActiveCoverLimit, initialActiveCoverLimit.sub(initialPolicy3CoverLimit));
-            
+
             // Confirm state is what we expect after charging premium
 
             // Check premiumsPaid
@@ -1330,14 +1330,14 @@ describe("SolaceCoverProduct", function() {
             let accountBalanceDeductedForHolder2 = WEEKLY_MAX_PREMIUM.sub(initialRewardPoints2);
             let accountBalanceDeductedForHolder3 = initialHolder3AccountBalance;
             let expectedSoteriaBalanceChange = accountBalanceDeductedForHolder1.add(accountBalanceDeductedForHolder2).add(accountBalanceDeductedForHolder3)
-            expect(await dai.balanceOf(solaceCoverProduct.address)).eq(initialContractDAIBalance.sub(expectedSoteriaBalanceChange))
-            expect(await dai.balanceOf(premiumPool.address)).eq(initialPremiumPoolDAIBalance.add(expectedSoteriaBalanceChange))
+            expect(await frax.balanceOf(solaceCoverProduct.address)).eq(initialContractFRAXBalance.sub(expectedSoteriaBalanceChange))
+            expect(await frax.balanceOf(premiumPool.address)).eq(initialPremiumPoolFRAXBalance.add(expectedSoteriaBalanceChange))
 
             // Soteria active cover limit check - policy 3 deactivated
             expect(await solaceCoverProduct.activeCoverLimit()).eq(initialActiveCoverLimit.sub(initialPolicy3CoverLimit))
             expect(await riskManager.activeCoverLimit()).eq(initialRMCoverAmount.sub(initialPolicy3CoverLimit))
             expect(await riskManager.activeCoverLimitPerStrategy(solaceCoverProduct.address)).eq(initialRMSoteriaCoverAmount.sub(initialPolicy3CoverLimit))
-            
+
             // Cover capacity check - should be increased by policy 3 initial cover limit
             expect(await solaceCoverProduct.availableCoverCapacity()).eq(initialAvailableCoverCapacity.add(initialPolicy3CoverLimit))
         })
@@ -1356,7 +1356,7 @@ describe("SolaceCoverProduct", function() {
             let depositAmount = BN.from(10);
             let WEEKLY_MAX_PREMIUM = coverLimit.div(10).mul(604800).div(31536000) // Override global WEEKLY_MAX_PREMIUM variable
 
-            // Activate policies for each user, 100 DAI cover limit with 10 DAI deposit
+            // Activate policies for each user, 100 FRAX cover limit with 10 FRAX deposit
             for (let user of users) {
                 await solaceCoverProduct.connect(governor).activatePolicy(user.address, coverLimit, depositAmount, [])
             }
@@ -1404,7 +1404,7 @@ describe("SolaceCoverProduct", function() {
     //         const minRequiredAccountBalance = maxRateNum.mul(ONE_WEEK).mul(initialCoverLimit).div(maxRateDenom)
     //         const withdrawAmount = initialAccountBalance.sub(minRequiredAccountBalance)
     //         expect(await usdc.balanceOf(usdcPolicyholder.address)).eq(0)
-            
+
     //         // Design as standalone unit test that has minimal side effects on pre-existing unit tests
     //         await solaceCoverProduct.connect(usdcPolicyholder).withdraw(1)
     //         expect(await solaceCoverProduct.accountBalanceOf(usdcPolicyholder.address)).eq(minRequiredAccountBalance)
@@ -1436,16 +1436,16 @@ describe("SolaceCoverProduct", function() {
         await provider.send("evm_mine", []) // Mine the next block
     }
 
-    async function manipulateDAIbalance(wallet: Wallet, desiredBalance: BN) {
-        const DAI_BALANCEOF_SLOT = 2;
+    async function manipulateFRAXbalance(wallet: Wallet, desiredBalance: BN) {
+        const FRAX_BALANCEOF_SLOT = 0;
         // Get storage slot index
         const index = utils.solidityKeccak256(
             ["uint256", "uint256"],
-            [wallet.address, DAI_BALANCEOF_SLOT] // key, slot
+            [wallet.address, FRAX_BALANCEOF_SLOT] // key, slot
           );
 
         // Manipulate local balance (needs to be bytes32 string)
-        await provider.send("hardhat_setStorageAt", [DAI_ADDRESS, index.toString(), toBytes32(desiredBalance).toString()])
+        await provider.send("hardhat_setStorageAt", [FRAX_ADDRESS, index.toString(), toBytes32(desiredBalance).toString()])
         await provider.send("evm_mine", []) // Mine the next block
     }
 

--- a/test/products/SolaceCoverProductFrax.test.ts
+++ b/test/products/SolaceCoverProductFrax.test.ts
@@ -616,35 +616,35 @@ describe("SolaceCoverProductFrax", function() {
             // Deactivate policyholder3 account (so we can repeat activatePolicy in subsequent tests)
             await solaceCoverProduct.connect(policyholder3).deactivatePolicy();
         })
-        it("cannot use a referral code, if premiumPaid < 100", async () => {
-            const referralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
-            expect(await solaceCoverProduct.premiumsPaidOf(policyholder1.address)).eq(0)
-            await expect(solaceCoverProduct.connect(policyholder1).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, INITIAL_DEPOSIT, referralCode)).to.revertedWith("cannot apply referral code if premium paid < referralThreshold")
-        })
+        // it("cannot use a referral code, if premiumPaid < 100", async () => {
+        //     const referralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
+        //     expect(await solaceCoverProduct.premiumsPaidOf(policyholder1.address)).eq(0)
+        //     await expect(solaceCoverProduct.connect(policyholder1).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, INITIAL_DEPOSIT, referralCode)).to.revertedWith("cannot apply referral code if premium paid < referralThreshold")
+        // })
         it("cannot use own referral code", async () => {
             // Temporary state change just for this state, set premiumPaidOf(policyholder3) = 100
-            await manipulatePremiumPaidOf(policyholder3, REFERRAL_THRESHOLD)
+            // await manipulatePremiumPaidOf(policyholder3, REFERRAL_THRESHOLD)
 
             // Create new wallet just for this unit test scope, to avoid creating side effects that impact other unit tests. It's a headfuck to work that out.
             const ownReferralCode = await getSolaceReferralCode(policyholder3, solaceCoverProduct)
             await expect(solaceCoverProduct.connect(governor).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, INITIAL_DEPOSIT, ownReferralCode)).to.revertedWith("cannot refer to self");
 
-            await manipulatePremiumPaidOf(policyholder3, BN.from(0))
-            expect(await solaceCoverProduct.premiumsPaidOf(policyholder3.address)).eq(0)
+            // await manipulatePremiumPaidOf(policyholder3, BN.from(0))
+            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder3.address)).eq(0)
         })
         it("cannot use an invalid referral code", async () => {
             // Temporary state change just for this state, set premiumPaidOf(policyholder3) = 100
-            await manipulatePremiumPaidOf(policyholder3, REFERRAL_THRESHOLD)
+            // await manipulatePremiumPaidOf(policyholder3, REFERRAL_THRESHOLD)
 
             await expect(solaceCoverProduct.connect(governor).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, INITIAL_DEPOSIT, FAKE_REFERRAL_CODE)).to.revertedWith("ECDSA: invalid signature 's' value")
 
-            await manipulatePremiumPaidOf(policyholder3, BN.from(0))
-            expect(await solaceCoverProduct.premiumsPaidOf(policyholder3.address)).eq(0)
+            // await manipulatePremiumPaidOf(policyholder3, BN.from(0))
+            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder3.address)).eq(0)
         })
 
         it("can use referral code only once", async () => {
             // Temporary state change just for this state, set premiumPaidOf(policyholder3) = 100
-            await manipulatePremiumPaidOf(policyholder3, REFERRAL_THRESHOLD)
+            // await manipulatePremiumPaidOf(policyholder3, REFERRAL_THRESHOLD)
 
             let referralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
 
@@ -665,8 +665,8 @@ describe("SolaceCoverProductFrax", function() {
             await solaceCoverProduct.connect(coverPromotionAdmin).setRewardPoints(policyholder3.address, 0);
             expect(await solaceCoverProduct.rewardPointsOf(policyholder1.address)).eq(0)
             expect(await solaceCoverProduct.rewardPointsOf(policyholder3.address)).eq(0)
-            await manipulatePremiumPaidOf(policyholder3, BN.from(0))
-            expect(await solaceCoverProduct.premiumsPaidOf(policyholder3.address)).eq(0)
+            // await manipulatePremiumPaidOf(policyholder3, BN.from(0))
+            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder3.address)).eq(0)
         })
     });
 
@@ -816,43 +816,43 @@ describe("SolaceCoverProductFrax", function() {
             await solaceCoverProduct.connect(policyholder1).updateCoverLimit(initialCoverLimit, []);
             expect (await solaceCoverProduct.cooldownStart(policyholder1.address)).eq(0)
         })
-        it("cannot use a referral code, if premiumPaid < 100", async () => {
-            let referralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
-            let coverLimit = await solaceCoverProduct.coverLimitOf(POLICY_ID_2);
-            await expect(solaceCoverProduct.connect(policyholder2).updateCoverLimit(coverLimit, referralCode)).to.revertedWith("cannot apply referral code if premium paid < referralThreshold")
-        })
+        // it("cannot use a referral code, if premiumPaid < 100", async () => {
+        //     let referralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
+        //     let coverLimit = await solaceCoverProduct.coverLimitOf(POLICY_ID_2);
+        //     await expect(solaceCoverProduct.connect(policyholder2).updateCoverLimit(coverLimit, referralCode)).to.revertedWith("cannot apply referral code if premium paid < referralThreshold")
+        // })
         it("cannot use invalid referral code", async () => {
             // Temporary state change just for this state, set premiumPaidOf(policyholder1) = 100
-            await manipulatePremiumPaidOf(policyholder1, REFERRAL_THRESHOLD)
+            // await manipulatePremiumPaidOf(policyholder1, REFERRAL_THRESHOLD)
 
             let coverLimit = await solaceCoverProduct.coverLimitOf(POLICY_ID_1);
             await expect(solaceCoverProduct.connect(policyholder1).updateCoverLimit(coverLimit, FAKE_REFERRAL_CODE)).to.be.reverted;
 
-            await manipulatePremiumPaidOf(policyholder1, BN.from(0))
-            expect(await solaceCoverProduct.premiumsPaidOf(policyholder1.address)).eq(0)
+            // await manipulatePremiumPaidOf(policyholder1, BN.from(0))
+            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder1.address)).eq(0)
         })
         it("cannot use own referral code", async () => {
             // Temporary state change just for this state, set premiumPaidOf(policyholder1) = 100
-            await manipulatePremiumPaidOf(policyholder1, REFERRAL_THRESHOLD)
+            // await manipulatePremiumPaidOf(policyholder1, REFERRAL_THRESHOLD)
 
             let ownReferralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
             let coverLimit = await solaceCoverProduct.coverLimitOf(POLICY_ID_1);
             await expect(solaceCoverProduct.connect(policyholder1).updateCoverLimit(coverLimit, ownReferralCode)).to.revertedWith("cannot refer to self");
 
-            await manipulatePremiumPaidOf(policyholder1, BN.from(0))
-            expect(await solaceCoverProduct.premiumsPaidOf(policyholder1.address)).eq(0)
+            // await manipulatePremiumPaidOf(policyholder1, BN.from(0))
+            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder1.address)).eq(0)
         })
         it("cannot use referral code of an inactive policy holder", async () => {
             // Temporary state change just for this state, set premiumPaidOf(policyholder2) = 100
-            await manipulatePremiumPaidOf(policyholder2, REFERRAL_THRESHOLD)
+            // await manipulatePremiumPaidOf(policyholder2, REFERRAL_THRESHOLD)
 
             expect(await solaceCoverProduct.policyStatus(POLICY_ID_3)).eq(false)
             let referralCode = await getSolaceReferralCode(policyholder3, solaceCoverProduct)
             let coverLimit = await solaceCoverProduct.coverLimitOf(POLICY_ID_2);
             await expect(solaceCoverProduct.connect(policyholder2).updateCoverLimit(coverLimit, referralCode)).to.revertedWith("referrer must be active policy holder");
 
-            await manipulatePremiumPaidOf(policyholder2, BN.from(0))
-            expect(await solaceCoverProduct.premiumsPaidOf(policyholder2.address)).eq(0)
+            // await manipulatePremiumPaidOf(policyholder2, BN.from(0))
+            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder2.address)).eq(0)
         })
         it("will not give reward points if isReferralOn == false", async () => {
             // Set isReferralOn to false
@@ -876,7 +876,7 @@ describe("SolaceCoverProductFrax", function() {
         })
         it("can use referral code only once", async () => {
             // Temporary state change just for this state, set premiumPaidOf(policyholder2) = 100
-            await manipulatePremiumPaidOf(policyholder2, REFERRAL_THRESHOLD)
+            // await manipulatePremiumPaidOf(policyholder2, REFERRAL_THRESHOLD)
 
             let referralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
             let coverLimit = await solaceCoverProduct.coverLimitOf(POLICY_ID_2);
@@ -900,8 +900,8 @@ describe("SolaceCoverProductFrax", function() {
             await solaceCoverProduct.connect(coverPromotionAdmin).setRewardPoints(policyholder2.address, 0);
             expect(await solaceCoverProduct.rewardPointsOf(policyholder1.address)).eq(0)
             expect(await solaceCoverProduct.rewardPointsOf(policyholder2.address)).eq(0)
-            await manipulatePremiumPaidOf(policyholder2, BN.from(0))
-            expect(await solaceCoverProduct.premiumsPaidOf(policyholder2.address)).eq(0)
+            // await manipulatePremiumPaidOf(policyholder2, BN.from(0))
+            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder2.address)).eq(0)
         })
     });
 
@@ -1248,6 +1248,10 @@ describe("SolaceCoverProductFrax", function() {
             // Policy 1: reward points can pay for premium in full
             // Policy 2: reward points can partially pay for premium, rest will come from account balance
             // Policy 3: reward points + account balance unable to fully pay for premium
+
+            await manipulatePremiumPaidOf(policyholder1, REFERRAL_THRESHOLD)
+            await manipulatePremiumPaidOf(policyholder2, REFERRAL_THRESHOLD)
+            await manipulatePremiumPaidOf(policyholder3, REFERRAL_THRESHOLD)
 
             // Set up reward points for policy 1 and 2 - with setRewardPoints()
             let EXCESS_REWARD_POINTS = WEEKLY_MAX_PREMIUM.mul(2)

--- a/test/products/SolaceCoverProductFrax.test.ts
+++ b/test/products/SolaceCoverProductFrax.test.ts
@@ -616,36 +616,16 @@ describe("SolaceCoverProductFrax", function() {
             // Deactivate policyholder3 account (so we can repeat activatePolicy in subsequent tests)
             await solaceCoverProduct.connect(policyholder3).deactivatePolicy();
         })
-        // it("cannot use a referral code, if premiumPaid < 100", async () => {
-        //     const referralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
-        //     expect(await solaceCoverProduct.premiumsPaidOf(policyholder1.address)).eq(0)
-        //     await expect(solaceCoverProduct.connect(policyholder1).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, INITIAL_DEPOSIT, referralCode)).to.revertedWith("cannot apply referral code if premium paid < referralThreshold")
-        // })
         it("cannot use own referral code", async () => {
-            // Temporary state change just for this state, set premiumPaidOf(policyholder3) = 100
-            // await manipulatePremiumPaidOf(policyholder3, REFERRAL_THRESHOLD)
-
             // Create new wallet just for this unit test scope, to avoid creating side effects that impact other unit tests. It's a headfuck to work that out.
             const ownReferralCode = await getSolaceReferralCode(policyholder3, solaceCoverProduct)
             await expect(solaceCoverProduct.connect(governor).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, INITIAL_DEPOSIT, ownReferralCode)).to.revertedWith("cannot refer to self");
-
-            // await manipulatePremiumPaidOf(policyholder3, BN.from(0))
-            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder3.address)).eq(0)
         })
         it("cannot use an invalid referral code", async () => {
-            // Temporary state change just for this state, set premiumPaidOf(policyholder3) = 100
-            // await manipulatePremiumPaidOf(policyholder3, REFERRAL_THRESHOLD)
-
             await expect(solaceCoverProduct.connect(governor).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, INITIAL_DEPOSIT, FAKE_REFERRAL_CODE)).to.revertedWith("ECDSA: invalid signature 's' value")
-
-            // await manipulatePremiumPaidOf(policyholder3, BN.from(0))
-            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder3.address)).eq(0)
         })
 
         it("can use referral code only once", async () => {
-            // Temporary state change just for this state, set premiumPaidOf(policyholder3) = 100
-            // await manipulatePremiumPaidOf(policyholder3, REFERRAL_THRESHOLD)
-
             let referralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
 
             let tx = await solaceCoverProduct.connect(governor).activatePolicy(policyholder3.address, INITIAL_COVER_LIMIT, INITIAL_DEPOSIT, referralCode);
@@ -665,8 +645,6 @@ describe("SolaceCoverProductFrax", function() {
             await solaceCoverProduct.connect(coverPromotionAdmin).setRewardPoints(policyholder3.address, 0);
             expect(await solaceCoverProduct.rewardPointsOf(policyholder1.address)).eq(0)
             expect(await solaceCoverProduct.rewardPointsOf(policyholder3.address)).eq(0)
-            // await manipulatePremiumPaidOf(policyholder3, BN.from(0))
-            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder3.address)).eq(0)
         })
     });
 
@@ -816,43 +794,20 @@ describe("SolaceCoverProductFrax", function() {
             await solaceCoverProduct.connect(policyholder1).updateCoverLimit(initialCoverLimit, []);
             expect (await solaceCoverProduct.cooldownStart(policyholder1.address)).eq(0)
         })
-        // it("cannot use a referral code, if premiumPaid < 100", async () => {
-        //     let referralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
-        //     let coverLimit = await solaceCoverProduct.coverLimitOf(POLICY_ID_2);
-        //     await expect(solaceCoverProduct.connect(policyholder2).updateCoverLimit(coverLimit, referralCode)).to.revertedWith("cannot apply referral code if premium paid < referralThreshold")
-        // })
         it("cannot use invalid referral code", async () => {
-            // Temporary state change just for this state, set premiumPaidOf(policyholder1) = 100
-            // await manipulatePremiumPaidOf(policyholder1, REFERRAL_THRESHOLD)
-
             let coverLimit = await solaceCoverProduct.coverLimitOf(POLICY_ID_1);
             await expect(solaceCoverProduct.connect(policyholder1).updateCoverLimit(coverLimit, FAKE_REFERRAL_CODE)).to.be.reverted;
-
-            // await manipulatePremiumPaidOf(policyholder1, BN.from(0))
-            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder1.address)).eq(0)
         })
         it("cannot use own referral code", async () => {
-            // Temporary state change just for this state, set premiumPaidOf(policyholder1) = 100
-            // await manipulatePremiumPaidOf(policyholder1, REFERRAL_THRESHOLD)
-
             let ownReferralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
             let coverLimit = await solaceCoverProduct.coverLimitOf(POLICY_ID_1);
             await expect(solaceCoverProduct.connect(policyholder1).updateCoverLimit(coverLimit, ownReferralCode)).to.revertedWith("cannot refer to self");
-
-            // await manipulatePremiumPaidOf(policyholder1, BN.from(0))
-            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder1.address)).eq(0)
         })
         it("cannot use referral code of an inactive policy holder", async () => {
-            // Temporary state change just for this state, set premiumPaidOf(policyholder2) = 100
-            // await manipulatePremiumPaidOf(policyholder2, REFERRAL_THRESHOLD)
-
             expect(await solaceCoverProduct.policyStatus(POLICY_ID_3)).eq(false)
             let referralCode = await getSolaceReferralCode(policyholder3, solaceCoverProduct)
             let coverLimit = await solaceCoverProduct.coverLimitOf(POLICY_ID_2);
             await expect(solaceCoverProduct.connect(policyholder2).updateCoverLimit(coverLimit, referralCode)).to.revertedWith("referrer must be active policy holder");
-
-            // await manipulatePremiumPaidOf(policyholder2, BN.from(0))
-            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder2.address)).eq(0)
         })
         it("will not give reward points if isReferralOn == false", async () => {
             // Set isReferralOn to false
@@ -875,9 +830,6 @@ describe("SolaceCoverProductFrax", function() {
             expect(await solaceCoverProduct.isReferralOn()).eq(true)
         })
         it("can use referral code only once", async () => {
-            // Temporary state change just for this state, set premiumPaidOf(policyholder2) = 100
-            // await manipulatePremiumPaidOf(policyholder2, REFERRAL_THRESHOLD)
-
             let referralCode = await getSolaceReferralCode(policyholder1, solaceCoverProduct)
             let coverLimit = await solaceCoverProduct.coverLimitOf(POLICY_ID_2);
             expect(await solaceCoverProduct.isReferralCodeUsed(policyholder2.address)).eq(false)
@@ -900,8 +852,6 @@ describe("SolaceCoverProductFrax", function() {
             await solaceCoverProduct.connect(coverPromotionAdmin).setRewardPoints(policyholder2.address, 0);
             expect(await solaceCoverProduct.rewardPointsOf(policyholder1.address)).eq(0)
             expect(await solaceCoverProduct.rewardPointsOf(policyholder2.address)).eq(0)
-            // await manipulatePremiumPaidOf(policyholder2, BN.from(0))
-            // expect(await solaceCoverProduct.premiumsPaidOf(policyholder2.address)).eq(0)
         })
     });
 
@@ -1249,6 +1199,7 @@ describe("SolaceCoverProductFrax", function() {
             // Policy 2: reward points can partially pay for premium, rest will come from account balance
             // Policy 3: reward points + account balance unable to fully pay for premium
 
+            // Need to manipuate premium paid to be >= 100, so reward points count in chargePremiums() computation
             await manipulatePremiumPaidOf(policyholder1, REFERRAL_THRESHOLD)
             await manipulatePremiumPaidOf(policyholder2, REFERRAL_THRESHOLD)
             await manipulatePremiumPaidOf(policyholder3, REFERRAL_THRESHOLD)

--- a/test/utilities/artifact_importer.ts
+++ b/test/utilities/artifact_importer.ts
@@ -88,6 +88,7 @@ export async function import_artifacts() {
 
   // soteria coverage product
   artifacts.SolaceCoverProduct = await tryImport(`${artifact_dir}/products/SolaceCoverProduct.sol/SolaceCoverProduct.json`);
+  artifacts.SolaceCoverProductFrax = await tryImport(`${artifact_dir}/products/SolaceCoverProductFrax.sol/SolaceCoverProductFrax.json`);
   return artifacts;
 }
 


### PR DESCRIPTION
Modified following anti-referral gaming mechanism

BEFORE
- Referral code doesn't work for referee, unless premiums paid >= 100

AFTER
- Referral code will work regardless of premiums paid
- However reward points won't be applied until premiums paid > 100

--

UPDATE 5 MAR 2022

Git merged SoteriaV2 branch (contains SolaceCoverProductV2.sol with multi-chain cover functionality added)
Added anti-referral gaming mechanism SolaceCoverProductV2.sol
Unit tests passing for SolaceCoverProduct.sol (on ETH mainnet fork), SolaceCoverProductFRAX.sol (on MATIC mainnet fork) and SolaceCoverProductV2.sol (on MATIC mainnet fork)

-- 

UPDATE 6 MAR 2022

Successful Mumbai testnet deploy of SolaceCoverProductV2. Required hardhat config with custom solc compiler optimiser runs of 300.